### PR TITLE
Fix a missing paren

### DIFF
--- a/proposals/threads/Overview.md
+++ b/proposals/threads/Overview.md
@@ -186,7 +186,7 @@ For example:
   ...)
 
 WebAssembly.instantiate(dataModuleBytes, {}).then(
-    ({instance} => {
+    ({instance}) => {
         let imports = {env: {memory: instance.exports.memory}};
         WebAssembly.instantiate(mainModuleBytes, imports).then(...);
     });


### PR DESCRIPTION
In section "Initializing Memory Only Once" the WebAssembly.instantiate is missing a paren.