### PR TITLE
Fix naming of `iextend` macro in math.def

### DIFF
--- a/document/core/exec/numerics.rst
+++ b/document/core/exec/numerics.rst
@@ -610,16 +610,16 @@ The integer result of predicates -- i.e., :ref:`tests <syntax-testop>` and :ref:
    \end{array}
 
 
-.. _op-iextend_s:
+.. _op-iextendn_s:
 
-:math:`\iextends_N(i)`
-......................
+:math:`\iextendns_N(i)`
+.......................
 
 * Return :math:`\extends_{M,N}(i)`.
 
 .. math::
    \begin{array}{lll@{\qquad}l}
-   \iextends_{N}(i) &=& \extends_{M,N}(i) \\
+   \iextendns_{N}(i) &=& \extends_{M,N}(i) \\
    \end{array}
 
 

--- a/document/core/syntax/instrindex.rst
+++ b/document/core/syntax/instrindex.rst
@@ -198,9 +198,9 @@ Instruction                          Opcode            Type                     
 :math:`\I64.\REINTERPRET\K{/}\F64`   :math:`\hex{BD}`  :math:`[\F64] \to [\I64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
 :math:`\F32.\REINTERPRET\K{/}\I32`   :math:`\hex{BE}`  :math:`[\I32] \to [\F32]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
 :math:`\F64.\REINTERPRET\K{/}\I64`   :math:`\hex{BF}`  :math:`[\I64] \to [\F64]`                   :ref:`validation <valid-cvtop>`           :ref:`execution <exec-cvtop>`, :ref:`operator <op-reinterpret>`
-:math:`\I32.\EXTEND\K{8\_s}`         :math:`\hex{C0}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextend_s>`
-:math:`\I32.\EXTEND\K{16\_s}`        :math:`\hex{C1}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextend_s>`
-:math:`\I64.\EXTEND\K{8\_s}`         :math:`\hex{C2}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextend_s>`
-:math:`\I64.\EXTEND\K{16\_s}`        :math:`\hex{C3}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextend_s>`
-:math:`\I64.\EXTEND\K{32\_s}`        :math:`\hex{C4}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextend_s>`
+:math:`\I32.\EXTEND\K{8\_s}`         :math:`\hex{C0}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
+:math:`\I32.\EXTEND\K{16\_s}`        :math:`\hex{C1}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
+:math:`\I64.\EXTEND\K{8\_s}`         :math:`\hex{C2}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
+:math:`\I64.\EXTEND\K{16\_s}`        :math:`\hex{C3}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
+:math:`\I64.\EXTEND\K{32\_s}`        :math:`\hex{C4}`  :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`            :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
 ===================================  ================  ==========================================  ========================================  ===============================================================

--- a/document/core/util/math.def
+++ b/document/core/util/math.def
@@ -826,7 +826,7 @@
 .. |iles| mathdef:: \xref{exec/numerics}{op-ile_s}{\F{ile\_s}}
 .. |igeu| mathdef:: \xref{exec/numerics}{op-ige_u}{\F{ige\_u}}
 .. |iges| mathdef:: \xref{exec/numerics}{op-ige_s}{\F{ige\_s}}
-.. |iextends| mathdef:: \xref{exec/numerics}{op-iextend_s}{\F{iextend{M}\_s}}
+.. |iextendns| mathdef:: \xref{exec/numerics}{op-iextendn_s}{\F{iextend}M\F{\_s}}}
 
 .. |fadd| mathdef:: \xref{exec/numerics}{op-fadd}{\F{fadd}}
 .. |fsub| mathdef:: \xref{exec/numerics}{op-fsub}{\F{fsub}}


### PR DESCRIPTION
See https://github.com/WebAssembly/threads/pull/54#pullrequestreview-53142165.