### PR TITLE
Add implementation of tryLockMutex to example

### DIFF
--- a/proposals/threads/Overview.md
+++ b/proposals/threads/Overview.md
@@ -46,7 +46,7 @@ mutex is unlocked. If its value is 1, the mutex is locked.
       (loop $retry
         ;; Try to lock the mutex. $tryLockMutex returns 1 if the mutex
         ;; was locked, and 0 otherwise.
-        (call $tryLockMutex)
+        (call $tryLockMutex (get_local $mutexAddr))
         (br_if $done)
         (drop)
         

--- a/proposals/threads/Overview.md
+++ b/proposals/threads/Overview.md
@@ -24,7 +24,7 @@ mutex is unlocked. If its value is 1, the mutex is locked.
     (param $mutexAddr i32) (result i32)
     ;; Attempt to grab the mutex. The cmpxchg operation atomically
     ;; does the following:
-    ;; - Loads the value at address 0.
+    ;; - Loads the value at $mutexAddr.
     ;; - If it is 0 (unlocked), set it to 1 (locked).
     ;; - Return the originally loaded value.
     (i32.atomic.rmw.cmpxchg


### PR DESCRIPTION
Also parameterize the functions on the mutex address.
I think this actually makes it more readable.