### PR TITLE
Fix example in ConditionalSegmentInitialization.md

### DIFF
--- a/proposals/threads/ConditionalSegmentInitialization.md
+++ b/proposals/threads/ConditionalSegmentInitialization.md
@@ -19,7 +19,7 @@ the previous initializations.
 For example:
 
 ```webassembly
-// The module.
+;; The module.
 (module
   (memory (export "memory") 1)
 


### PR DESCRIPTION
It looks like `addOne` func expects counter to be at address 0. 
But data declaration puts counter at address 1. 

Also, changed comment from `//` to `;;` to be in line with other comments in WebAssembly example.