### PR TITLE
Add `wake` and `ixx.wait` instructions to spec doc

### DIFF
--- a/document/core/appendix/index-instructions.rst
+++ b/document/core/appendix/index-instructions.rst
@@ -204,6 +204,9 @@ Instruction                                              Binary Opcode          
 :math:`\I64.\EXTEND\K{8\_s}`                             :math:`\hex{C2}`           :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`                 :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
 :math:`\I64.\EXTEND\K{16\_s}`                            :math:`\hex{C3}`           :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`                 :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
 :math:`\I64.\EXTEND\K{32\_s}`                            :math:`\hex{C4}`           :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`                 :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
+:math:`\WAKE~\memarg`                                    :math:`\hex{FE}~\hex{00}`  :math:`[\I32~\I64] \to [\I64]`              :ref:`validation <valid-wake>`
+:math:`\I32.\WAIT~\memarg`                               :math:`\hex{FE}~\hex{01}`  :math:`[\I32~\I32~\I64] \to [\I32]`         :ref:`validation <valid-wait>`
+:math:`\I64.\WAIT~\memarg`                               :math:`\hex{FE}~\hex{02}`  :math:`[\I32~\I64~\I64] \to [\I32]`         :ref:`validation <valid-wait>`
 :math:`\I32.\ATOMICLOAD~\memarg`                         :math:`\hex{FE}~\hex{10}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-atomic-load>`          :ref:`execution <exec-atomic-load>`
 :math:`\I64.\ATOMICLOAD~\memarg`                         :math:`\hex{FE}~\hex{11}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-atomic-load>`          :ref:`execution <exec-atomic-load>`
 :math:`\I32.\ATOMICLOAD\K{8\_u}~\memarg`                 :math:`\hex{FE}~\hex{12}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-atomic-loadn>`         :ref:`execution <exec-atomic-loadn>`

--- a/document/core/appendix/index-instructions.rst
+++ b/document/core/appendix/index-instructions.rst
@@ -204,9 +204,9 @@ Instruction                                              Binary Opcode          
 :math:`\I64.\EXTEND\K{8\_s}`                             :math:`\hex{C2}`           :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`                 :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
 :math:`\I64.\EXTEND\K{16\_s}`                            :math:`\hex{C3}`           :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`                 :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
 :math:`\I64.\EXTEND\K{32\_s}`                            :math:`\hex{C4}`           :math:`[\I64] \to [\I64]`                   :ref:`validation <valid-unop>`                 :ref:`execution <exec-unop>`, :ref:`operator <op-iextendn_s>`
-:math:`\WAKE~\memarg`                                    :math:`\hex{FE}~\hex{00}`  :math:`[\I32~\I64] \to [\I64]`              :ref:`validation <valid-wake>`
-:math:`\I32.\WAIT~\memarg`                               :math:`\hex{FE}~\hex{01}`  :math:`[\I32~\I32~\I64] \to [\I32]`         :ref:`validation <valid-wait>`
-:math:`\I64.\WAIT~\memarg`                               :math:`\hex{FE}~\hex{02}`  :math:`[\I32~\I64~\I64] \to [\I32]`         :ref:`validation <valid-wait>`
+:math:`\ATOMICWAKE~\memarg`                              :math:`\hex{FE}~\hex{00}`  :math:`[\I32~\I64] \to [\I64]`              :ref:`validation <valid-atomic-wake>`
+:math:`\I32.\ATOMICWAIT~\memarg`                         :math:`\hex{FE}~\hex{01}`  :math:`[\I32~\I32~\I64] \to [\I32]`         :ref:`validation <valid-atomic-wait>`
+:math:`\I64.\ATOMICWAIT~\memarg`                         :math:`\hex{FE}~\hex{02}`  :math:`[\I32~\I64~\I64] \to [\I32]`         :ref:`validation <valid-atomic-wait>`
 :math:`\I32.\ATOMICLOAD~\memarg`                         :math:`\hex{FE}~\hex{10}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-atomic-load>`          :ref:`execution <exec-atomic-load>`
 :math:`\I64.\ATOMICLOAD~\memarg`                         :math:`\hex{FE}~\hex{11}`  :math:`[\I32] \to [\I64]`                   :ref:`validation <valid-atomic-load>`          :ref:`execution <exec-atomic-load>`
 :math:`\I32.\ATOMICLOAD\K{8\_u}~\memarg`                 :math:`\hex{FE}~\hex{12}`  :math:`[\I32] \to [\I32]`                   :ref:`validation <valid-atomic-loadn>`         :ref:`execution <exec-atomic-loadn>`

--- a/document/core/binary/instructions.rst
+++ b/document/core/binary/instructions.rst
@@ -172,6 +172,8 @@ Atomic Memory Instructions
 
 Each variant of :ref:`atomic memory instruction <syntax-instr-atomic-memory>` is encoded with a different byte code. Loads, stores and RMW instructions are followed by the encoding of their |memarg| immediate.
 
+.. _binary-wake:
+.. _binary-wait:
 .. _binary-atomic-load:
 .. _binary-atomic-loadn:
 .. _binary-atomic-store:
@@ -181,7 +183,16 @@ Each variant of :ref:`atomic memory instruction <syntax-instr-atomic-memory>` is
 
 .. math::
    \begin{array}{llclll}
-   \production{instruction} & \Binstr &::=& \dots \\ &&|&
+   \production{instruction} & \Binstr &::=& \dots && \phantom{thisshouldbeenough} \\ &&|&
+     \hex{FE}~\hex{00}~~m{:}\Bmemarg &\Rightarrow& \WAKE~m \\ &&|&
+     \hex{FE}~\hex{01}~~m{:}\Bmemarg &\Rightarrow& \I32.\WAKE~m \\ &&|&
+     \hex{FE}~\hex{02}~~m{:}\Bmemarg &\Rightarrow& \I64.\WAKE~m \\
+   \end{array}
+
+
+.. math::
+   \begin{array}{llclll}
+   \phantom{\production{instruction}} & \phantom{\Binstr} &\phantom{::=}& \phantom{\dots} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
      \hex{FE}~\hex{10}~~m{:}\Bmemarg &\Rightarrow& \I32.\ATOMICLOAD~m \\ &&|&
      \hex{FE}~\hex{11}~~m{:}\Bmemarg &\Rightarrow& \I64.\ATOMICLOAD~m \\ &&|&
      \hex{FE}~\hex{12}~~m{:}\Bmemarg &\Rightarrow& \I32.\ATOMICLOAD\K{8\_u}~m \\ &&|&

--- a/document/core/binary/instructions.rst
+++ b/document/core/binary/instructions.rst
@@ -172,8 +172,8 @@ Atomic Memory Instructions
 
 Each variant of :ref:`atomic memory instruction <syntax-instr-atomic-memory>` is encoded with a different byte code. Loads, stores and RMW instructions are followed by the encoding of their |memarg| immediate.
 
-.. _binary-wake:
-.. _binary-wait:
+.. _binary-atomic-wake:
+.. _binary-atomic-wait:
 .. _binary-atomic-load:
 .. _binary-atomic-loadn:
 .. _binary-atomic-store:
@@ -184,9 +184,9 @@ Each variant of :ref:`atomic memory instruction <syntax-instr-atomic-memory>` is
 .. math::
    \begin{array}{llclll}
    \production{instruction} & \Binstr &::=& \dots && \phantom{thisshouldbeenough} \\ &&|&
-     \hex{FE}~\hex{00}~~m{:}\Bmemarg &\Rightarrow& \WAKE~m \\ &&|&
-     \hex{FE}~\hex{01}~~m{:}\Bmemarg &\Rightarrow& \I32.\WAKE~m \\ &&|&
-     \hex{FE}~\hex{02}~~m{:}\Bmemarg &\Rightarrow& \I64.\WAKE~m \\
+     \hex{FE}~\hex{00}~~m{:}\Bmemarg &\Rightarrow& \ATOMICWAKE~m \\ &&|&
+     \hex{FE}~\hex{01}~~m{:}\Bmemarg &\Rightarrow& \I32.\ATOMICWAIT~m \\ &&|&
+     \hex{FE}~\hex{02}~~m{:}\Bmemarg &\Rightarrow& \I64.\ATOMICWAIT~m \\
    \end{array}
 
 

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -292,8 +292,8 @@ Instructions in this group are concerned with accessing :ref:`linear memory <syn
      \ATOMICXCHG \\
    \production{instruction} & \instr &::=&
      \dots ~|~ \\&&&
-     \WAKE~\memarg ~|~ \\&&&
-     \K{i}\X{nn}\K{.}\WAIT~\memarg ~|~ \\&&&
+     \ATOMICWAKE~\memarg ~|~ \\&&&
+     \K{i}\X{nn}\K{.}\ATOMICWAIT~\memarg ~|~ \\&&&
      \K{i}\X{nn}\K{.}\ATOMICLOAD~\memarg ~|~ \\&&&
      \K{i}\X{nn}\K{.}\ATOMICSTORE~\memarg ~|~ \\&&&
      \K{i}\X{nn}\K{.}\ATOMICLOAD\K{8\_u}~\memarg ~|~
@@ -329,12 +329,13 @@ this action conditionally, if the read value is equal to a provided comparison
 argument. All other :ref:`atomicops <syntax-atomicop>` have behavior of the
 :ref:`ibinop <syntax-ibinop>` of the same name.
 
-The |WAKE| and |WAIT| instructions provide primitive synchronization between
-:ref:`threads <syntax-thread>`. The |WAIT| instructions atomically load a value
-from the calculated *effective address* and compare it to an expected value. If
-they are equal, the thread is then suspended until a given timeout expires or
-another thread wakes it. The |WAKE| instruction wakes threads that are waiting
-on a given address, up to a given maximum.
+The |ATOMICWAKE| and |ATOMICWAIT| instructions provide primitive
+synchronization between :ref:`threads <syntax-thread>`. The |ATOMICWAIT|
+instructions atomically load a value from the calculated effective address and
+compare it to an expected value. If they are equal, the thread is then
+suspended until a given timeout expires or another thread wakes it. The
+|ATOMICWAKE| instruction wakes threads that are waiting on a given address, up
+to a given maximum.
 
 
 .. index:: ! control instruction, ! structured control, ! label, ! block, ! branch, ! unwinding, result type, label index, function index, type index, vector, trap, function, table, function type

--- a/document/core/syntax/instructions.rst
+++ b/document/core/syntax/instructions.rst
@@ -292,6 +292,8 @@ Instructions in this group are concerned with accessing :ref:`linear memory <syn
      \ATOMICXCHG \\
    \production{instruction} & \instr &::=&
      \dots ~|~ \\&&&
+     \WAKE~\memarg ~|~ \\&&&
+     \K{i}\X{nn}\K{.}\WAIT~\memarg ~|~ \\&&&
      \K{i}\X{nn}\K{.}\ATOMICLOAD~\memarg ~|~ \\&&&
      \K{i}\X{nn}\K{.}\ATOMICSTORE~\memarg ~|~ \\&&&
      \K{i}\X{nn}\K{.}\ATOMICLOAD\K{8\_u}~\memarg ~|~
@@ -326,6 +328,13 @@ doesn't use the read value, but instead stores its argument unmodified. The
 this action conditionally, if the read value is equal to a provided comparison
 argument. All other :ref:`atomicops <syntax-atomicop>` have behavior of the
 :ref:`ibinop <syntax-ibinop>` of the same name.
+
+The |WAKE| and |WAIT| instructions provide primitive synchronization between
+:ref:`threads <syntax-thread>`. The |WAIT| instructions atomically load a value
+from the calculated *effective address* and compare it to an expected value. If
+they are equal, the thread is then suspended until a given timeout expires or
+another thread wakes it. The |WAKE| instruction wakes threads that are waiting
+on a given address, up to a given maximum.
 
 
 .. index:: ! control instruction, ! structured control, ! label, ! block, ! branch, ! unwinding, result type, label index, function index, type index, vector, trap, function, table, function type

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -222,6 +222,8 @@ Lexically, an |Toffset| or |Talign| phrase is considered a single :ref:`keyword 
 Atomic Memory Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. _text-wake:
+.. _text-wait:
 .. _text-atomic-load:
 .. _text-atomic-loadn:
 .. _text-atomic-store:
@@ -234,7 +236,15 @@ The offset immediate to atomic memory instructions is optional, and defaults to
 
 .. math::
    \begin{array}{llclll}
-   \production{instruction} & \Tplaininstr_I &::=& \dots \\ &&|&
+   \production{instruction} & \Tplaininstr_I &::=& \dots \phantom{thisshouldbeenoughnowitissee} && \phantom{thisshouldbeenough} \\ &&|&
+     \text{wake}~~m{:}\Tmemarg_4 &\Rightarrow& \WAKE~m \\ &&|&
+     \text{i32.wait}~~m{:}\Tmemarg_4 &\Rightarrow& \I32.\WAIT~m \\ &&|&
+     \text{i64.wait}~~m{:}\Tmemarg_8 &\Rightarrow& \I64.\WAIT~m \\
+   \end{array}
+
+.. math::
+   \begin{array}{llclll}
+   \phantom{\production{instruction}} & \phantom{\Tplaininstr_I} &\phantom{::=}& \phantom{thisisenough} && \phantom{thisshouldbeenough} \\[-2ex] &&|&
      \text{i32.atomic{.}load}~~m{:}\Tmemarg_4 &\Rightarrow& \I32.\ATOMICLOAD~m \\ &&|&
      \text{i64.atomic{.}load}~~m{:}\Tmemarg_8 &\Rightarrow& \I64.\ATOMICLOAD~m \\ &&|&
      \text{i32.atomic{.}load8\_u}~~m{:}\Tmemarg_1 &\Rightarrow& \I32.\ATOMICLOAD\K{8\_u}~m \\ &&|&

--- a/document/core/text/instructions.rst
+++ b/document/core/text/instructions.rst
@@ -222,8 +222,8 @@ Lexically, an |Toffset| or |Talign| phrase is considered a single :ref:`keyword 
 Atomic Memory Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. _text-wake:
-.. _text-wait:
+.. _text-atomic-wake:
+.. _text-atomic-wait:
 .. _text-atomic-load:
 .. _text-atomic-loadn:
 .. _text-atomic-store:
@@ -237,9 +237,9 @@ The offset immediate to atomic memory instructions is optional, and defaults to
 .. math::
    \begin{array}{llclll}
    \production{instruction} & \Tplaininstr_I &::=& \dots \phantom{thisshouldbeenoughnowitissee} && \phantom{thisshouldbeenough} \\ &&|&
-     \text{wake}~~m{:}\Tmemarg_4 &\Rightarrow& \WAKE~m \\ &&|&
-     \text{i32.wait}~~m{:}\Tmemarg_4 &\Rightarrow& \I32.\WAIT~m \\ &&|&
-     \text{i64.wait}~~m{:}\Tmemarg_8 &\Rightarrow& \I64.\WAIT~m \\
+     \text{atomic.wake}~~m{:}\Tmemarg_4 &\Rightarrow& \ATOMICWAKE~m \\ &&|&
+     \text{i32.atomic.wait}~~m{:}\Tmemarg_4 &\Rightarrow& \I32.\ATOMICWAIT~m \\ &&|&
+     \text{i64.atomic.wait}~~m{:}\Tmemarg_8 &\Rightarrow& \I64.\ATOMICWAIT~m \\
    \end{array}
 
 .. math::

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -367,8 +367,8 @@
 .. |DEMOTE| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{demote}}
 .. |REINTERPRET| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{reinterpret}}
 
-.. |WAKE| mathdef:: \xref{syntax/instructions}{syntax-instr-atomic-memory}{\K{wake}}
-.. |WAIT| mathdef:: \xref{syntax/instructions}{syntax-instr-atomic-memory}{\K{wait}}
+.. |ATOMICWAKE| mathdef:: \xref{syntax/instructions}{syntax-instr-atomic-memory}{\K{atomic.wake}}
+.. |ATOMICWAIT| mathdef:: \xref{syntax/instructions}{syntax-instr-atomic-memory}{\K{atomic.wait}}
 .. |ATOMICADD| mathdef:: \xref{syntax/instructions}{syntax-instr-atomic-memory}{\K{add}}
 .. |ATOMICSUB| mathdef:: \xref{syntax/instructions}{syntax-instr-atomic-memory}{\K{sub}}
 .. |ATOMICAND| mathdef:: \xref{syntax/instructions}{syntax-instr-atomic-memory}{\K{and}}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -367,6 +367,8 @@
 .. |DEMOTE| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{demote}}
 .. |REINTERPRET| mathdef:: \xref{syntax/instructions}{syntax-instr-numeric}{\K{reinterpret}}
 
+.. |WAKE| mathdef:: \xref{syntax/instructions}{syntax-instr-atomic-memory}{\K{wake}}
+.. |WAIT| mathdef:: \xref{syntax/instructions}{syntax-instr-atomic-memory}{\K{wait}}
 .. |ATOMICADD| mathdef:: \xref{syntax/instructions}{syntax-instr-atomic-memory}{\K{add}}
 .. |ATOMICSUB| mathdef:: \xref{syntax/instructions}{syntax-instr-atomic-memory}{\K{sub}}
 .. |ATOMICAND| mathdef:: \xref{syntax/instructions}{syntax-instr-atomic-memory}{\K{and}}

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -436,7 +436,7 @@ Atomic Memory Instructions
 :math:`\WAKE~\memarg`
 .....................
 
-* The memory :math:`C.\MEMS[0]` must be defined in the context.
+* The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to :math:`4`.
 
@@ -444,7 +444,7 @@ Atomic Memory Instructions
 
 .. math::
    \frac{
-     C.\MEMS[0] = \memtype
+     C.\CMEMS[0] = \memtype
      \qquad
      2^{\memarg.\ALIGN} = 4
    }{
@@ -456,7 +456,7 @@ Atomic Memory Instructions
 :math:`t\K{.}\WAIT~\memarg`
 ...........................
 
-* The memory :math:`C.\MEMS[0]` must be defined in the context.
+* The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to the :ref:`width <syntax-valtype>` of :math:`t` divided by :math:`8`.
 
@@ -464,7 +464,7 @@ Atomic Memory Instructions
 
 .. math::
    \frac{
-     C.\MEMS[0] = \memtype
+     C.\CMEMS[0] = \memtype
      \qquad
      2^{\memarg.\ALIGN} = |t|/8
    }{

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -431,6 +431,46 @@ Memory Instructions
 Atomic Memory Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. _valid-wake:
+
+:math:`\WAKE~\memarg`
+.....................
+
+* The memory :math:`C.\MEMS[0]` must be defined in the context.
+
+* The alignment :math:`2^{\memarg.\ALIGN}` must be equal to :math:`4`.
+
+* Then the instruction is valid with type :math:`[\I32~\I64] \to [\I64]`.
+
+.. math::
+   \frac{
+     C.\MEMS[0] = \memtype
+     \qquad
+     2^{\memarg.\ALIGN} = 4
+   }{
+     C \vdash \WAKE~\memarg : [\I32~\I64] \to [\I64]
+   }
+
+.. _valid-wait:
+
+:math:`t\K{.}\WAIT~\memarg`
+...........................
+
+* The memory :math:`C.\MEMS[0]` must be defined in the context.
+
+* The alignment :math:`2^{\memarg.\ALIGN}` must be equal to the :ref:`width <syntax-valtype>` of :math:`t` divided by :math:`8`.
+
+* Then the instruction is valid with type :math:`[\I32~t~\I64] \to [\I32]`.
+
+.. math::
+   \frac{
+     C.\MEMS[0] = \memtype
+     \qquad
+     2^{\memarg.\ALIGN} = |t|/8
+   }{
+     C \vdash t\K{.}\WAIT~\memarg : [\I32~t~\I64] \to [\I32]
+   }
+
 .. _valid-atomic-load:
 
 :math:`t\K{.}\ATOMICLOAD~\memarg`

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -431,9 +431,9 @@ Memory Instructions
 Atomic Memory Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. _valid-wake:
+.. _valid-atomic-wake:
 
-:math:`\WAKE~\memarg`
+:math:`\ATOMICWAKE~\memarg`
 .....................
 
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
@@ -448,12 +448,12 @@ Atomic Memory Instructions
      \qquad
      2^{\memarg.\ALIGN} = 4
    }{
-     C \vdash \WAKE~\memarg : [\I32~\I64] \to [\I64]
+     C \vdash \ATOMICWAKE~\memarg : [\I32~\I64] \to [\I64]
    }
 
-.. _valid-wait:
+.. _valid-atomic-wait:
 
-:math:`t\K{.}\WAIT~\memarg`
+:math:`t\K{.}\ATOMICWAIT~\memarg`
 ...........................
 
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
@@ -468,7 +468,7 @@ Atomic Memory Instructions
      \qquad
      2^{\memarg.\ALIGN} = |t|/8
    }{
-     C \vdash t\K{.}\WAIT~\memarg : [\I32~t~\I64] \to [\I32]
+     C \vdash t\K{.}\ATOMICWAIT~\memarg : [\I32~t~\I64] \to [\I32]
    }
 
 .. _valid-atomic-load:


### PR DESCRIPTION
Syntax, validation, binary and text sections are completed. Execution section is still TODO.