### PR TITLE
Define postMessage of shared Memory

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -212,9 +212,7 @@ fetch('demo.wasm').then(response =>
 
 Note: WebAssembly semantics are defined in terms of an abstract [=store=], representing the state of the WebAssembly abstract machine. WebAssembly operations take a store and return an updated store.
 
-Each [=agent=] has an <dfn>associated store</dfn>. When a new agent is created, its associated store is set to the result of [=init_store=]().
-
-Note: In this specification, no WebAssembly-related objects, memory or addresses can be shared among agents in an [=agent cluster=]. In a future version of WebAssembly, this may change.
+Each [=agent cluster=] has an <dfn>associated store</dfn>. When a new agent cluster is created, its associated store is set to the result of [=init_store=](). The associated store of an [=agent=] is defined to be the associated store of the [=agent cluster=] that it belongs to.
 
 Elements of the WebAssembly store may be <dfn>identified with</dfn> JavaScript values. In particular, each WebAssembly [=memory instance=] with a corresponding {{Memory}} object is identified with a JavaScript [=Data Block=]; modifications to this Data Block are identified to updating the agent's store to a store which reflects those changes, and vice versa.
 

--- a/document/web-api/index.bs
+++ b/document/web-api/index.bs
@@ -20,8 +20,8 @@ Markup Shorthands: css no, markdown yes
     "status": "Current Editor's Draft"
   },
   "WEBASSEMBLY": {
-    "href": "https://webassembly.github.io/spec/",
-    "title": "WebAssembly Specification",
+    "href": "https://webassembly.github.io/spec/core/",
+    "title": "WebAssembly Core Specification",
     "publisher": "W3C WebAssembly Community Group",
     "status": "Draft"
   },
@@ -40,15 +40,21 @@ urlPrefix: https://tc39.github.io/ecma262/; spec: ECMA-262
         text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
     type: interface
         text: ArrayBuffer; url: sec-arraybuffer-objects
-urlPrefix: https://webassembly.github.io/spec/; spec: WebAssembly; type: dfn
+    type: abstract-op
+        text: IsSharedArrayBuffer; url: sec-issharedarraybuffer
+    type: dfn
+        text: SharedArrayBuffer; url: sec-sharedarraybuffer-objects
+        text: agent cluster; url: sec-agent-clusters
+urlPrefix: https://webassembly.github.io/spec/core/; spec: WebAssembly; type: dfn
     text: function index; url: syntax/modules.html#syntax-funcidx
-urlPrefix: https://webassembly.github.io/spec/document/js-api/; spec: WASMJS
+urlPrefix: https://webassembly.github.io/spec/js-api/index.html; spec: WASMJS
     type: namespace
         text: WebAssembly; url: #namespacedef-webassembly
     type: interface
         text: CompileError; url: #compileerror
         text: Module; url: #module
         text: WebAssemblyInstantiatedSource; url: #dictdef-webassemblyinstantiatedsource
+        text: Memory; url: #memories
     type: dfn
         text: compile a WebAssembly module; url: #compile-a-webassembly-module
         text: instantiate a WebAssembly module; url: #instantiate-a-webassembly-module
@@ -56,6 +62,8 @@ urlPrefix: https://webassembly.github.io/spec/document/js-api/; spec: WASMJS
         text: asynchronously compile a webassembly module; url: #asynchronously-compile-a-webassembly-module
         text: instantiate a promise of a module; url: #instantiate-a-promise-of-a-module
         text: Exported Function; url: #exported-function
+        text: identified with; url: #identified-with
+        text: create a memory object; url: #create-a-memory-object
 url:https://html.spec.whatwg.org/#cors-same-origin;text:CORS-same-origin;type:dfn;spec:HTML
 url:https://fetch.spec.whatwg.org/#concept-body-consume-body;text:consume body;type:dfn;spec:FETCH
 </pre>
@@ -121,6 +129,29 @@ Note: This algorithm accepts a {{Response}} object, or a
          1. [=Reject=] |returnValue| with |reason|.
      1. Return |returnValue|.
 </div>
+
+<h2 id="serialization">Serialization</h2>
+
+On the Web, {{Memory}} has the <code>[<a extended-attribute>Serializable</a>]</code> extended attribute.
+
+The [=serialization steps=], given |value|, |serialized| and |forStorage|, are:
+
+    1.  If [$IsSharedArrayBuffer$](|value|.\[[BufferObject]]) is false, then
+        throw a "<a exception>DataCloneError</a>" {{DOMException}}.
+
+    1.  Set |serialized|.\[[MemoryBuffer]] to the [=sub-serialization=]
+        of |value|.\[[BufferObject]]. Rethrow any exceptions.
+
+    Note: Serializing and deserializing the [=SharedArrayBuffer=] will check that
+          |forStorage| is false and the tranfer occurs within an [=agent cluster=].
+
+The [=deserialization steps=], given |serialized| and |value|, are:
+
+    1.  Let |sab| be the [=sub-deserialization=] of |serialized|.\[[MemoryBuffer]].
+
+    1.  Let |memaddr| be the memory address [=identified with=] |sab|.\[[ArrayBufferData]].
+
+    1. [=Create a memory object=] from |memaddr| and return the result.
 
 <h2 id="conventions">Developer-Facing Display Conventions</h2>
 


### PR DESCRIPTION
[spec] Normative: Store is per agent cluster

With the WebAssembly threads proposal, a single Memory can be shared between
multiple agents within an agent cluster. This patch associates a WebAssembly
store with an agent cluster, rather than an agent, and updates the WebAssembly
JS API to define the store for an agent as the store for its surrounding
agent cluster.

[spec] Normative: Define serialization for SAB Memory

The semantics here are
- forStorage serialization is disallowed
- Transfers are only permitted within an agent cluster
- Transfer of Memory backed by SharedArrayBuffers makes the buffer available in
  the source and the destination, with no resulting detached buffer.
- Transfer of Memory backed by ArrayBuffers is disallowed.

This specification attempts to be well-integrated with HTML by defining
n terms of the serialization behavior of Memory as a platform object, and
using the sub-serialization of the underlying SharedArrayBuffer to check
for transferring within an agent cluster, and not to IndexedDB.

Based on the earlier PR at WebAssembly/design#1074