### PR TITLE
Spec text/formal: atomic on non-shared memory is a validation error

### DIFF
--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -438,13 +438,17 @@ Atomic Memory Instructions
 
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
+* Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
+
+* The shareability :math:`\share` must be |MSHARED|.
+
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to :math:`4`.
 
 * Then the instruction is valid with type :math:`[\I32~\I64] \to [\I64]`.
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \memtype
+     C.\CMEMS[0] = \limits~\MSHARED
      \qquad
      2^{\memarg.\ALIGN} = 4
    }{
@@ -458,13 +462,17 @@ Atomic Memory Instructions
 
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
+* Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
+
+* The shareability :math:`\share` must be |MSHARED|.
+
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to the :ref:`width <syntax-valtype>` of :math:`t` divided by :math:`8`.
 
 * Then the instruction is valid with type :math:`[\I32~t~\I64] \to [\I32]`.
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \memtype
+     C.\CMEMS[0] = \limits~\MSHARED
      \qquad
      2^{\memarg.\ALIGN} = |t|/8
    }{
@@ -478,13 +486,17 @@ Atomic Memory Instructions
 
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
+* Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
+
+* The shareability :math:`\share` must be |MSHARED|.
+
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to the :ref:`width <syntax-valtype>` of :math:`t` divided by :math:`8`.
 
 * Then the instruction is valid with type :math:`[\I32] \to [t]`.
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \memtype
+     C.\CMEMS[0] = \limits~\MSHARED
      \qquad
      2^{\memarg.\ALIGN} = |t|/8
    }{
@@ -499,13 +511,17 @@ Atomic Memory Instructions
 
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
+* Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
+
+* The shareability :math:`\share` must be |MSHARED|.
+
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to :math:`N/8`.
 
 * Then the instruction is valid with type :math:`[\I32] \to [t]`.
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \memtype
+     C.\CMEMS[0] = \limits~\MSHARED
      \qquad
      2^{\memarg.\ALIGN} = N/8
    }{
@@ -520,13 +536,17 @@ Atomic Memory Instructions
 
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
+* Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
+
+* The shareability :math:`\share` must be |MSHARED|.
+
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to the :ref:`width <syntax-valtype>` of :math:`t` divided by :math:`8`.
 
 * Then the instruction is valid with type :math:`[\I32~t] \to []`.
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \memtype
+     C.\CMEMS[0] = \limits~\MSHARED
      \qquad
      2^{\memarg.\ALIGN} = |t|/8
    }{
@@ -541,13 +561,17 @@ Atomic Memory Instructions
 
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
+* Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
+
+* The shareability :math:`\share` must be |MSHARED|.
+
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to :math:`N/8`.
 
 * Then the instruction is valid with type :math:`[\I32~t] \to []`.
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \memtype
+     C.\CMEMS[0] = \limits~\MSHARED
      \qquad
      2^{\memarg.\ALIGN} = N/8
    }{
@@ -562,13 +586,17 @@ Atomic Memory Instructions
 
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
+* Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
+
+* The shareability :math:`\share` must be |MSHARED|.
+
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to the :ref:`width <syntax-valtype>` of :math:`t` divided by :math:`8`.
 
 * Then the instruction is valid with type :math:`[\I32~t] \to [t]`.
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \memtype
+     C.\CMEMS[0] = \limits~\MSHARED
      \qquad
      2^{\memarg.\ALIGN} = |t|/8
    }{
@@ -582,13 +610,17 @@ Atomic Memory Instructions
 
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
+* Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
+
+* The shareability :math:`\share` must be |MSHARED|.
+
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to :math:`N/8`.
 
 * Then the instruction is valid with type :math:`[\I32~t] \to [t]`.
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \memtype
+     C.\CMEMS[0] = \limits~\MSHARED
      \qquad
      2^{\memarg.\ALIGN} = N/8
    }{
@@ -602,13 +634,17 @@ Atomic Memory Instructions
 
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
+* Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
+
+* The shareability :math:`\share` must be |MSHARED|.
+
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to the :ref:`width <syntax-valtype>` of :math:`t` divided by :math:`8`.
 
 * Then the instruction is valid with type :math:`[\I32~t~t] \to [t]`.
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \memtype
+     C.\CMEMS[0] = \limits~\MSHARED
      \qquad
      2^{\memarg.\ALIGN} = |t|/8
    }{
@@ -622,13 +658,17 @@ Atomic Memory Instructions
 
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
+* Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
+
+* The shareability :math:`\share` must be |MSHARED|.
+
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to :math:`N/8`.
 
 * Then the instruction is valid with type :math:`[\I32~t~t] \to [t]`.
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \memtype
+     C.\CMEMS[0] = \limits~\MSHARED
      \qquad
      2^{\memarg.\ALIGN} = N/8
    }{


### PR DESCRIPTION
As indicated in the [overview](https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md#atomic-memory-accesses), "attempting to use atomic access operators on non-shared linear memory is a validation error".

Question: is "shareability" the right informal name for the _shared_ portion of the memory type? I debated "sharedness".