### PR TITLE
[js-api] Fix `WebAssembly.Memory` buffer accessor

### DIFF
--- a/document/js-api/index.bs
+++ b/document/js-api/index.bs
@@ -639,15 +639,11 @@ Immediately after a WebAssembly [=memory.grow=] instruction executes, perform th
     1. Let |memory| be the Memory instance.
     1. Let |memaddr| be |memory|.\[[Memory]].
     1. Let |block| be a [=Data Block=] which is [=identified with=] the underlying memory of |memaddr|.
-    1. If |block| is a [=Shared Data Block=],
-        1. Let |map| be the [=surrounding agent=]'s associated [=Memory object cache=].
-        1. Assert: |map|[|memaddr|] [=map/exists=].
-        1. Let |newMemory| be |map|[|memaddr|].
-        1. Let |newBufferObject| be |newMemory|.\[[BufferObject]].
-        1. Set |memory|.\[[BufferObject]] to |newBufferObject|.
-        1. Return |newBufferObject|.
-    1. Otherwise,
-        1. Return |memory|.\[[BufferObject]].
+    1. Let |buffer| be |memory|.\[[BufferObject]].
+    1. If |block| is a [=Shared Data Block=] and the length of |block| is not equal to |buffer|.\[[ArrayBufferByteLength]],
+        1. Let |newBuffer| to the result of [=create a memory buffer|creating a memory buffer=] from |memaddr|.
+        1. Set |memory|.\[[BufferObject]] to |newBuffer|.
+    1. Return |memory|.\[[BufferObject]].
 </div>
 
 <h3 id="tables">Tables</h3>


### PR DESCRIPTION
A given agent will only have one `WebAssembly.Memory` object that
references a given `Data Block`. Even if a `Memory` is `postMessage`'d
to another worker and back, the agent's memory object cache will contain
a reference to the `Memory` object associated with that `Data Block`.

So if another agent shares a memory with this agent, and the other agent
grows the memory, the only thing that's different in this agent is the
`Data Block`'s length. So we check that in the getter, and if it's
different we create a new buffer object and store it on the cached
`Memory` object.