### PR TITLE
[interp] Add command to spawn threads

### DIFF
--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -312,7 +312,7 @@ cmd:
 module with given failure string
   <action>                                   ;; perform action and print results
   <assertion>                                ;; assert result of an action
-  ( threads <assertion>* )                   ;; run all assertions in parallel
+  ( spawn <name>?> action )                  ;; spawn a new thread and run an action
   <meta>                                     ;; meta command
 
 module:
@@ -323,6 +323,7 @@ module:
 action:
   ( invoke <name>? <string> <expr>* )        ;; invoke function export
   ( get <name>? <string> )                   ;; get global export
+  ( join <name> )                            ;; join named thread and return its value
 
 assertion:
   ( assert_return <action> <expr>* )         ;; assert action has expected results

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -312,6 +312,7 @@ cmd:
 module with given failure string
   <action>                                   ;; perform action and print results
   <assertion>                                ;; assert result of an action
+  ( threads <assertion>* )                   ;; run all assertions in parallel
   <meta>                                     ;; meta command
 
 module:

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -312,7 +312,7 @@ cmd:
 module with given failure string
   <action>                                   ;; perform action and print results
   <assertion>                                ;; assert result of an action
-  ( spawn <name>?> action )                  ;; spawn a new thread and run an action
+  ( spawn <name>? <action> )                 ;; spawn a new thread and run an action
   <meta>                                     ;; meta command
 
 module:

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -354,6 +354,9 @@ let of_action mods act =
       Some (of_wrapper mods x_opt name (get gt), [t])
     | _ -> None
     )
+  (* TODO(binji): *)
+  | Join x ->
+    assert false
 
 let of_assertion' mods act name args wrapper_opt =
   let act_js, act_wrapper_opt = of_action mods act in
@@ -390,7 +393,7 @@ let of_assertion mods ass =
     of_assertion' mods act "assert_exhaustion" [] None
 
 (* TODO(binji): *)
-let of_threads mods asss = assert false
+let of_spawn mods x_opt act = assert false
 
 let of_command mods cmd =
   "\n// " ^ Filename.basename cmd.at.left.file ^
@@ -412,8 +415,8 @@ let of_command mods cmd =
     of_assertion' mods act "run" [] None ^ "\n"
   | Assertion ass ->
     of_assertion mods ass ^ "\n"
-  | Threads asss ->
-    of_threads mods asss ^ "\n"
+  | Spawn (x_opt, act) ->
+    of_spawn mods x_opt act ^ "\n"
   | Meta _ -> assert false
 
 let of_script scr =

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -389,6 +389,9 @@ let of_assertion mods ass =
   | AssertExhaustion (act, _) ->
     of_assertion' mods act "assert_exhaustion" [] None
 
+(* TODO(binji): *)
+let of_threads mods asss = assert false
+
 let of_command mods cmd =
   "\n// " ^ Filename.basename cmd.at.left.file ^
     ":" ^ string_of_int cmd.at.left.line ^ "\n" ^
@@ -409,6 +412,8 @@ let of_command mods cmd =
     of_assertion' mods act "run" [] None ^ "\n"
   | Assertion ass ->
     of_assertion mods ass ^ "\n"
+  | Threads asss ->
+    of_threads mods asss ^ "\n"
   | Meta _ -> assert false
 
 let of_script scr =

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -313,6 +313,10 @@ let run_action act =
     | None -> Assert.error act.at "undefined export"
     )
 
+  (* TODO(binji) *)
+  | Join x ->
+    assert false
+
 let assert_result at correct got print_expect expect =
   if not correct then begin
     print_string "Result: "; print_result got;
@@ -467,7 +471,7 @@ let rec run_command cmd =
     end
 
   (* TODO(binji) *)
-  | Threads asss -> assert false
+  | Spawn (x_opt, act) -> assert false
 
   | Meta cmd ->
     run_meta cmd

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -466,6 +466,9 @@ let rec run_command cmd =
       run_assertion ass
     end
 
+  (* TODO(binji) *)
+  | Threads asss -> assert false
+
   | Meta cmd ->
     run_meta cmd
 

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -10,6 +10,7 @@ type action = action' Source.phrase
 and action' =
   | Invoke of var option * Ast.name * Ast.literal list
   | Get of var option * Ast.name
+  | Join of var
 
 type assertion = assertion' Source.phrase
 and assertion' =
@@ -29,7 +30,7 @@ and command' =
   | Register of Ast.name * var option
   | Action of action
   | Assertion of assertion
-  | Threads of assertion list
+  | Spawn of var option * action
   | Meta of meta
 
 and meta = meta' Source.phrase

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -29,6 +29,7 @@ and command' =
   | Register of Ast.name * var option
   | Action of action
   | Assertion of assertion
+  | Threads of assertion list
   | Meta of meta
 
 and meta = meta' Source.phrase

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -467,6 +467,8 @@ let action act =
     Node ("invoke" ^ access x_opt name, List.map literal lits)
   | Get (x_opt, name) ->
     Node ("get" ^ access x_opt name, [])
+  | Join x ->
+    Node ("join " ^ x.it, [])
 
 let assertion mode ass =
   match ass.it with
@@ -496,7 +498,7 @@ let command mode cmd =
     Node ("register " ^ name n ^ var_opt x_opt, [])
   | Action act -> action act
   | Assertion ass -> assertion mode ass
-  | Threads asss -> Node ("threads", List.map (assertion mode) asss)
+  | Spawn (x_opt, act) -> Node ("spawn " ^ var_opt x_opt, [action act])
   | Meta _ -> assert false
 
 let script mode scr = List.map (command mode) scr

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -496,6 +496,7 @@ let command mode cmd =
     Node ("register " ^ name n ^ var_opt x_opt, [])
   | Action act -> action act
   | Assertion ass -> assertion mode ass
+  | Threads asss -> Node ("threads", List.map (assertion mode) asss)
   | Meta _ -> assert false
 
 let script mode scr = List.map (command mode) scr

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -425,7 +425,8 @@ rule token = parse
 
   | "script" { SCRIPT }
   | "register" { REGISTER }
-  | "threads" { THREADS }
+  | "spawn" { SPAWN }
+  | "join" { JOIN }
   | "invoke" { INVOKE }
   | "get" { GET }
   | "assert_malformed" { ASSERT_MALFORMED }

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -425,6 +425,7 @@ rule token = parse
 
   | "script" { SCRIPT }
   | "register" { REGISTER }
+  | "threads" { THREADS }
   | "invoke" { INVOKE }
   | "get" { GET }
   | "assert_malformed" { ASSERT_MALFORMED }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -157,7 +157,7 @@ let inline_type_explicit (c : context) x ft at =
 %token FUNC START TYPE PARAM RESULT LOCAL GLOBAL
 %token TABLE ELEM MEMORY DATA OFFSET IMPORT EXPORT TABLE
 %token MODULE BIN QUOTE
-%token SCRIPT REGISTER INVOKE GET
+%token SCRIPT REGISTER THREADS INVOKE GET
 %token ASSERT_MALFORMED ASSERT_INVALID ASSERT_SOFT_INVALID ASSERT_UNLINKABLE
 %token ASSERT_RETURN ASSERT_RETURN_CANONICAL_NAN ASSERT_RETURN_ARITHMETIC_NAN ASSERT_TRAP ASSERT_EXHAUSTION
 %token INPUT OUTPUT
@@ -816,11 +816,16 @@ assertion :
   | LPAR ASSERT_TRAP action STRING RPAR { AssertTrap ($3, $4) @@ at () }
   | LPAR ASSERT_EXHAUSTION action STRING RPAR { AssertExhaustion ($3, $4) @@ at () }
 
+assertion_list :
+  | /* empty */ { [] }
+  | assertion assertion_list { $1 :: $2 }
+
 cmd :
   | action { Action $1 @@ at () }
   | assertion { Assertion $1 @@ at () }
   | script_module { Module (fst $1, snd $1) @@ at () }
   | LPAR REGISTER name module_var_opt RPAR { Register ($3, $4) @@ at () }
+  | LPAR THREADS assertion_list RPAR { Threads $3 @@ at () }
   | meta { Meta $1 @@ at () }
 
 cmd_list :

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -157,7 +157,7 @@ let inline_type_explicit (c : context) x ft at =
 %token FUNC START TYPE PARAM RESULT LOCAL GLOBAL
 %token TABLE ELEM MEMORY DATA OFFSET IMPORT EXPORT TABLE
 %token MODULE BIN QUOTE
-%token SCRIPT REGISTER THREADS INVOKE GET
+%token SCRIPT REGISTER SPAWN JOIN INVOKE GET
 %token ASSERT_MALFORMED ASSERT_INVALID ASSERT_SOFT_INVALID ASSERT_UNLINKABLE
 %token ASSERT_RETURN ASSERT_RETURN_CANONICAL_NAN ASSERT_RETURN_ARITHMETIC_NAN ASSERT_TRAP ASSERT_EXHAUSTION
 %token INPUT OUTPUT
@@ -781,8 +781,14 @@ inline_module :  /* Sugar */
 inline_module1 :  /* Sugar */
   | module_fields1 { Textual ($1 (empty_context ()) () @@ at ()) @@ at () }
 
-
 /* Scripts */
+
+thread_var_opt :
+  | /* empty */ { None }
+  | thread_var { Some $1 }
+
+thread_var :
+  | VAR { $1 @@ at () }
 
 script_var_opt :
   | /* empty */ { None }
@@ -800,6 +806,8 @@ action :
     { Invoke ($3, $4, $5) @@ at () }
   | LPAR GET module_var_opt name RPAR
     { Get ($3, $4) @@ at() }
+  | LPAR JOIN thread_var RPAR
+    { Join $3 @@ at () }
 
 assertion :
   | LPAR ASSERT_MALFORMED script_module STRING RPAR
@@ -825,7 +833,7 @@ cmd :
   | assertion { Assertion $1 @@ at () }
   | script_module { Module (fst $1, snd $1) @@ at () }
   | LPAR REGISTER name module_var_opt RPAR { Register ($3, $4) @@ at () }
-  | LPAR THREADS assertion_list RPAR { Threads $3 @@ at () }
+  | LPAR SPAWN thread_var_opt action RPAR { Spawn ($3, $4) @@ at () }
   | meta { Meta $1 @@ at () }
 
 cmd_list :


### PR DESCRIPTION
This command is meant to execute each action on a separate thread, then
validate that each returns the expected value.

It's currently unimplemented in both `script/run.ml` and `script/js.ml`.