### PR TITLE
[interpreter] Add `initThreads` hook to JS output

### DIFF
--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -146,8 +146,8 @@ function assert_return_arithmetic_nan(action) {
     throw new Error("Wasm return value NaN expected, got " + actual);
   };
 }
-
 |}
+
 
 (* Context *)
 

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -471,7 +471,11 @@ let rec run_command cmd =
     end
 
   (* TODO(binji) *)
-  | Thread (x_opt, act) -> assert false
+  | Thread (x_opt, act) ->
+    quote := cmd :: !quote;
+    if not !Flags.dry then begin
+      assert false
+    end
 
   | Meta cmd ->
     run_meta cmd


### PR DESCRIPTION
A threaded test requires a more substantial harness than can be provided
in one JavaScript file, and must be implemented differently for Web JS
engines vs. console-based JS engines.

The idea is that the surrounding harness will implement the
initThreads() function, and replace the `instance` and `register`
functions to send messages to the Worker threads.

The `initThreads()` function is async so it can block until the threads
are ready. The entire function is wrapped in an `async` function to
allow for the `join` command (not yet implemented) to block.