### PR TITLE
[interpreter] Implement trivial wait/notify cases

### DIFF
--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -282,9 +282,9 @@ let rec step (c : config) : config =
         (try
           assert (sz = None);
           check_align addr ty sz e.at;
-          let v = Memory.load_value mem addr offset ty
-          in if v = ve then
-            assert false  (* Unimplemented *)
+          let v = Memory.load_value mem addr offset ty in
+          if v = ve then
+            assert false  (* TODO *)
           else
             I32 1l :: vs', []  (* Not equal *)
         with exn -> vs', [Trapping (memory_error e.at exn) @@ e.at])
@@ -293,7 +293,7 @@ let rec step (c : config) : config =
           if count = 0l then
             I32 0l :: vs', []  (* Trivial case waking 0 waiters *)
           else
-            assert false  (* Unimplemented *)
+            assert false  (* TODO *)
 
       | MemorySize, vs ->
         let mem = memory frame.inst (0l @@ e.at) in

--- a/test/core/atomic.wast
+++ b/test/core/atomic.wast
@@ -465,10 +465,10 @@
 (assert_invalid (module (memory 1 1) (func (drop (i64.atomic.rmw16.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))) "atomic accesses require shared memory")
 (assert_invalid (module (memory 1 1) (func (drop (i64.atomic.rmw32.cmpxchg_u (i32.const 0) (i64.const 0) (i64.const 0))))) "atomic accesses require shared memory")
 
-;; TODO: *.atomic.wait and atomic.notify (unimplemented in exec)
-
 (module
   (memory 1 1 shared)
+
+  (func (export "init") (param $value i64) (i64.store (i32.const 0) (local.get $value)))
 
   (func (export "atomic.notify") (param $addr i32) (param $count i32) (result i32)
       (atomic.notify (local.get 0) (local.get 1)))
@@ -477,3 +477,8 @@
   (func (export "i64.atomic.wait") (param $addr i32) (param $expected i64) (param $timeout i64) (result i32)
       (i64.atomic.wait (local.get 0) (local.get 1) (local.get 2)))
 )
+
+(invoke "init" (i64.const 0xffffffffffff))
+(assert_return (invoke "i32.atomic.wait" (i32.const 0) (i32.const 0) (i64.const 0)) (i32.const 1))
+(assert_return (invoke "i64.atomic.wait" (i32.const 0) (i64.const 0) (i64.const 0)) (i32.const 1))
+(assert_return (invoke "atomic.notify" (i32.const 0) (i32.const 0)) (i32.const 0))


### PR DESCRIPTION
`*.atomic.wait` only waits if the loaded value is equal to the expected
value. So we can test some simple cases without threads by ensuring that
the loaded value doesn't match.

Similarly `atomic.notify` will do nothing if the count is 0.