### PR TITLE
Allow atomic operations on unshared memories

### DIFF
--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -446,7 +446,7 @@ Atomic Memory Instructions
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \limits~\MSHARED
+     C.\CMEMS[0] = \memtype
      \qquad
      2^{\memarg.\ALIGN} = 4
    }{
@@ -468,7 +468,7 @@ Atomic Memory Instructions
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \limits~\MSHARED
+     C.\CMEMS[0] = \memtype
      \qquad
      2^{\memarg.\ALIGN} = |t|/8
    }{
@@ -490,7 +490,7 @@ Atomic Memory Instructions
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \limits~\MSHARED
+     C.\CMEMS[0] = \memtype
      \qquad
      2^{\memarg.\ALIGN} = |t|/8
    }{
@@ -513,7 +513,7 @@ Atomic Memory Instructions
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \limits~\MSHARED
+     C.\CMEMS[0] = \memtype
      \qquad
      2^{\memarg.\ALIGN} = N/8
    }{
@@ -536,7 +536,7 @@ Atomic Memory Instructions
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \limits~\MSHARED
+     C.\CMEMS[0] = \memtype
      \qquad
      2^{\memarg.\ALIGN} = |t|/8
    }{
@@ -559,7 +559,7 @@ Atomic Memory Instructions
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \limits~\MSHARED
+     C.\CMEMS[0] = \memtype
      \qquad
      2^{\memarg.\ALIGN} = N/8
    }{
@@ -582,7 +582,7 @@ Atomic Memory Instructions
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \limits~\MSHARED
+     C.\CMEMS[0] = \memtype
      \qquad
      2^{\memarg.\ALIGN} = |t|/8
    }{
@@ -604,7 +604,7 @@ Atomic Memory Instructions
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \limits~\MSHARED
+     C.\CMEMS[0] = \memtype
      \qquad
      2^{\memarg.\ALIGN} = N/8
    }{
@@ -626,7 +626,7 @@ Atomic Memory Instructions
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \limits~\MSHARED
+     C.\CMEMS[0] = \memtype
      \qquad
      2^{\memarg.\ALIGN} = |t|/8
    }{
@@ -648,7 +648,7 @@ Atomic Memory Instructions
 
 .. math::
    \frac{
-     C.\CMEMS[0] = \limits~\MSHARED
+     C.\CMEMS[0] = \memtype
      \qquad
      2^{\memarg.\ALIGN} = N/8
    }{

--- a/document/core/valid/instructions.rst
+++ b/document/core/valid/instructions.rst
@@ -440,8 +440,6 @@ Atomic Memory Instructions
 
 * Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
 
-* The sharedness :math:`\share` must be |MSHARED|.
-
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to :math:`4`.
 
 * Then the instruction is valid with type :math:`[\I32~\I64] \to [\I64]`.
@@ -464,8 +462,6 @@ Atomic Memory Instructions
 
 * Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
 
-* The sharedness :math:`\share` must be |MSHARED|.
-
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to the :ref:`width <syntax-valtype>` of :math:`t` divided by :math:`8`.
 
 * Then the instruction is valid with type :math:`[\I32~t~\I64] \to [\I32]`.
@@ -487,8 +483,6 @@ Atomic Memory Instructions
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
 * Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
-
-* The sharedness :math:`\share` must be |MSHARED|.
 
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to the :ref:`width <syntax-valtype>` of :math:`t` divided by :math:`8`.
 
@@ -513,8 +507,6 @@ Atomic Memory Instructions
 
 * Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
 
-* The sharedness :math:`\share` must be |MSHARED|.
-
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to :math:`N/8`.
 
 * Then the instruction is valid with type :math:`[\I32] \to [t]`.
@@ -537,8 +529,6 @@ Atomic Memory Instructions
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
 * Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
-
-* The sharedness :math:`\share` must be |MSHARED|.
 
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to the :ref:`width <syntax-valtype>` of :math:`t` divided by :math:`8`.
 
@@ -563,8 +553,6 @@ Atomic Memory Instructions
 
 * Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
 
-* The sharedness :math:`\share` must be |MSHARED|.
-
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to :math:`N/8`.
 
 * Then the instruction is valid with type :math:`[\I32~t] \to []`.
@@ -588,8 +576,6 @@ Atomic Memory Instructions
 
 * Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
 
-* The sharedness :math:`\share` must be |MSHARED|.
-
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to the :ref:`width <syntax-valtype>` of :math:`t` divided by :math:`8`.
 
 * Then the instruction is valid with type :math:`[\I32~t] \to [t]`.
@@ -611,8 +597,6 @@ Atomic Memory Instructions
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
 * Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
-
-* The sharedness :math:`\share` must be |MSHARED|.
 
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to :math:`N/8`.
 
@@ -636,8 +620,6 @@ Atomic Memory Instructions
 
 * Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
 
-* The sharedness :math:`\share` must be |MSHARED|.
-
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to the :ref:`width <syntax-valtype>` of :math:`t` divided by :math:`8`.
 
 * Then the instruction is valid with type :math:`[\I32~t~t] \to [t]`.
@@ -659,8 +641,6 @@ Atomic Memory Instructions
 * The memory :math:`C.\CMEMS[0]` must be defined in the context.
 
 * Let :math:`\limits~\share` be the :ref:`memory type <syntax-memtype>` :math:`C.\CMEMS[0]`.
-
-* The sharedness :math:`\share` must be |MSHARED|.
 
 * The alignment :math:`2^{\memarg.\ALIGN}` must be equal to :math:`N/8`.
 

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -277,6 +277,7 @@ let rec step (c : config) : config =
         with exn -> vs', [Trapping (memory_error e.at exn) @@ e.at]);
 
       | AtomicWait {offset; ty; sz; _}, I64 timeout :: ve :: I32 i :: vs' ->
+        (* TODO: Trap if memory is not shared *)
         let mem = memory frame.inst (0l @@ e.at) in
         let addr = I64_convert.extend_i32_u i in
         (try

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -137,6 +137,7 @@ let type_cvtop at = function
 
 (* Expressions *)
 
+(* TODO: Remove sharability requirements *)
 let check_memop (c : context) (memop : 'a memop) (sh: sharability option)
     get_sz at =
   let MemoryType (_, shared) = memory c (0l @@ at) in

--- a/proposals/threads/Globals.md
+++ b/proposals/threads/Globals.md
@@ -1,3 +1,4 @@
+
 # Import/Export mutable globals proposal
 
 This has been separated into


### PR DESCRIPTION
As discussed in the CG on November 12, 2019 and in #144. Specifically,
all atomic accesses are now allowed to validate and execute normally
on unshared memories and wait operations trap when used with unshared
memories.

The PR updates Overview.md and makes a best-effort
attempt at updating the spec, making no changes when there is
already a TODO for updating spec text. It also adds new TODO comments
to the reference interpreter where changes will have to be made.