### PR TITLE
Add a note for WebAssembly.Memory.prototype.grow return value

### DIFF
--- a/proposals/threads/Overview.md
+++ b/proposals/threads/Overview.md
@@ -514,9 +514,12 @@ thrown.
 
 Return `ret` as a Number value.
 
-Note: When [`IsSharedArrayBuffer`][](`M.[[BufferObject]]`) is true, the value `ret`
-should be the result of an atomic read-modify-write of the new size to the
-internal [\[\[ArrayBufferByteLength\]\]][] slot. 
+Note: When [`IsSharedArrayBuffer`][](`M.[[BufferObject]]`) is true, the return
+value should be the result of an atomic read-modify-write of the new size
+to the internal [\[\[ArrayBufferByteLength\]\]][] slot. The `ret` value will be
+the value in pages read from the internal [\[\[ArrayBufferByteLength\]\]][] slot 
+before the modification to the resized size, which will be the current size of
+the memory.
 
 ### `WebAssembly.Memory.prototype.buffer`
 

--- a/proposals/threads/Overview.md
+++ b/proposals/threads/Overview.md
@@ -507,12 +507,16 @@ Otherwise:
 
 Let `d` be [`ToNonWrappingUint32`][](`delta`).
 
-Let `ret` be the current size of memory in pages (before resizing).
+Let `ret` be the current size of memory in pages (before resizing). 
 
 Perform [`Memory.grow`][] with delta `d`. On failure, a [`RangeError`][] is
 thrown.
 
 Return `ret` as a Number value.
+
+Note: When [`IsSharedArrayBuffer`][](`M.[[BufferObject]]`) is true, the value `ret`
+should be the result of an atomic read-modify-write of the new size to the
+internal [\[\[ArrayBufferByteLength\]\]][] slot. 
 
 ### `WebAssembly.Memory.prototype.buffer`
 

--- a/proposals/threads/Overview.md
+++ b/proposals/threads/Overview.md
@@ -507,7 +507,7 @@ Otherwise:
 
 Let `d` be [`ToNonWrappingUint32`][](`delta`).
 
-Let `ret` be the current size of memory in pages (before resizing). 
+Let `ret` be the current size of memory in pages (before resizing).
 
 Perform [`Memory.grow`][] with delta `d`. On failure, a [`RangeError`][] is
 thrown.


### PR DESCRIPTION
The current text specifies the return value to be the current size of memory in pages (before resizing), but this is somewhat ambiguous and can lead to implementation specific behavior. For example, engines can decide to return the value at the time the grow method was called, or at the time the memory was updated, and these can be different values depending on the strictness of the implementation itself, and if there are multiple grow calls that occur at the same time. 

Add a note to clarify that the return value should essentially be an atomic RMW to the length of the underlying buffer. The implication of this is that more than one grow call cannot return the same value.