### PR TITLE
Add edge case tests for cmpxchg

### DIFF
--- a/test/core/atomic.wast
+++ b/test/core/atomic.wast
@@ -323,7 +323,15 @@
 (assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
 
 (invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw8.cmpxchg_u" (i32.const 0) (i32.const 0x11111111) (i32.const 0xcdcdcdcd)) (i32.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
 (assert_return (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 0) (i32.const 0) (i32.const 0xcafecafe)) (i32.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i32.atomic.rmw16.cmpxchg_u" (i32.const 0) (i32.const 0x11111111) (i32.const 0xcafecafe)) (i32.const 0x1111))
 (assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
 
 (invoke "init" (i64.const 0x1111111111111111))
@@ -331,11 +339,23 @@
 (assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
 
 (invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw8.cmpxchg_u" (i32.const 0) (i64.const 0x1111111111111111) (i64.const 0x4242424242424242)) (i64.const 0x11))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
 (assert_return (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 0) (i64.const 0) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
 (assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
 
 (invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw16.cmpxchg_u" (i32.const 0) (i64.const 0x1111111111111111) (i64.const 0xbeefbeefbeefbeef)) (i64.const 0x1111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
 (assert_return (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 0) (i64.const 0) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
+(assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
+
+(invoke "init" (i64.const 0x1111111111111111))
+(assert_return (invoke "i64.atomic.rmw32.cmpxchg_u" (i32.const 0) (i64.const 0x1111111111111111) (i64.const 0xcabba6e5cabba6e5)) (i64.const 0x11111111))
 (assert_return (invoke "i64.atomic.load" (i32.const 0)) (i64.const 0x1111111111111111))
 
 ;; *.atomic.rmw*.cmpxchg (compare true)


### PR DESCRIPTION
While implementing wasm-threading in JavaScriptCore, we found that this edge cases are not tested in spec-tests.
To clarify cmpxchg behavior, this patch adds them to spec-tests.