### PR TITLE
[interpreter] Threading

### DIFF
--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -397,7 +397,7 @@ assertion:
 
 result:
   ( <val_type>.const <numpat> )              ;; numeric result
-  ( oneof result* )                          ;; non-deterministic result
+  ( either result+ )                         ;; non-deterministic result
 
 numpat:
   <value>                                    ;; literal result

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -374,6 +374,8 @@ binscript: <cmd>*
 cmd:
   <module>                                   ;; define, validate, and initialize module
   ( register <string> <name>? )              ;; register module for imports
+  ( thread <name>? cmd* )                    ;; spawn thread
+  ( wait <name> )                            ;; join thread
   <action>                                   ;; perform action and print results
   <assertion>                                ;; assert result of an action
 
@@ -394,7 +396,8 @@ assertion:
   ( assert_trap <module> <failure> )         ;; assert module traps on instantiation
 
 result:
-  ( <val_type>.const <numpat> )
+  ( <val_type>.const <numpat> )              ;; numeric result
+  ( oneof result* )                          ;; non-deterministic result
 
 numpat:
   <value>                                    ;; literal result

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -374,10 +374,13 @@ binscript: <cmd>*
 cmd:
   <module>                                   ;; define, validate, and initialize module
   ( register <string> <name>? )              ;; register module for imports
-  ( thread <name>? cmd* )                    ;; spawn thread
+  ( thread <name>? <shared>* cmd* )          ;; spawn thread
   ( wait <name> )                            ;; join thread
   <action>                                   ;; perform action and print results
   <assertion>                                ;; assert result of an action
+
+shared:
+  ( shared ( module <name> ) )
 
 module:
   ( module <name>? binary <string>* )        ;; module in binary format (may be malformed)

--- a/interpreter/exec/eval.mli
+++ b/interpreter/exec/eval.mli
@@ -1,10 +1,20 @@
 open Values
 open Instance
 
+type config
+type thread_id
+type status = Running | Result of value list | Trap of exn
+
 exception Link of Source.region * string
 exception Trap of Source.region * string
 exception Crash of Source.region * string
 exception Exhaustion of Source.region * string
 
-val init : Ast.module_ -> extern list -> module_inst (* raises Link, Trap *)
-val invoke : func_inst -> value list -> value list (* raises Trap *)
+val empty_config : config
+
+val spawn : config -> thread_id * config
+val clear : config -> thread_id -> config
+val status : config -> thread_id -> status
+val step : config -> thread_id -> config
+val invoke : config -> thread_id -> func_inst -> value list -> config (* raises Trap *)
+val init : config -> thread_id -> Ast.module_ -> extern list -> module_inst * config (* raises Link, Trap *)

--- a/interpreter/main/main.ml
+++ b/interpreter/main/main.ml
@@ -42,13 +42,13 @@ let () =
     configure ();
     Arg.parse argspec
       (fun file -> add_arg ("(input " ^ quote file ^ ")")) usage;
-    let config = Run.config () in
-    List.iter (fun arg -> if not (Run.run_string config arg) then exit 1) !args;
+    let context = Run.context () in
+    List.iter (fun arg -> if not (Run.run_string context arg) then exit 1) !args;
     if !args = [] then Flags.interactive := true;
     if !Flags.interactive then begin
       Flags.print_sig := true;
       banner ();
-      Run.run_stdin config
+      Run.run_stdin context
     end
   with exn ->
     flush_all ();

--- a/interpreter/main/main.ml
+++ b/interpreter/main/main.ml
@@ -31,6 +31,8 @@ let argspec = Arg.align
   "-h", Arg.Clear Flags.harness, " exclude harness for JS conversion";
   "-d", Arg.Set Flags.dry, " dry, do not run program";
   "-t", Arg.Set Flags.trace, " trace execution";
+  "-r", Arg.Int Random.init, " set non-determinism random seed";
+  "-rr", Arg.Unit Random.self_init, " randomize non-determinism random seed";
   "-v", Arg.Unit banner, " show version"
 ]
 
@@ -40,12 +42,13 @@ let () =
     configure ();
     Arg.parse argspec
       (fun file -> add_arg ("(input " ^ quote file ^ ")")) usage;
-    List.iter (fun arg -> if not (Run.run_string arg) then exit 1) !args;
+    let config = Run.config () in
+    List.iter (fun arg -> if not (Run.run_string config arg) then exit 1) !args;
     if !args = [] then Flags.interactive := true;
     if !Flags.interactive then begin
       Flags.print_sig := true;
       banner ();
-      Run.run_stdin ()
+      Run.run_stdin config
     end
   with exn ->
     flush_all ();

--- a/interpreter/runtime/instance.ml
+++ b/interpreter/runtime/instance.ml
@@ -39,3 +39,10 @@ let extern_type_of = function
 
 let export inst name =
   try Some (List.assoc name inst.exports) with Not_found -> None
+
+let shared_export (_, ex) = shared_extern_type (extern_type_of ex)
+let shared_module inst =
+  if List.for_all (fun ex -> shared_export ex = Shared) inst.exports then
+    Shared
+  else
+    Unshared

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -475,8 +475,7 @@ let rec of_command c cmd =
     "});\n"
   | Wait x_opt ->
     "wait(" ^ of_var_opt c.threads x_opt ^ ");\n"
-  | Meta _
-  | Implicit _ -> assert false
+  | Meta _ -> assert false
 
 let of_script scr =
   (if !Flags.harness then harness else "") ^

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -164,8 +164,8 @@ function match_result(actual, expected) {
   }
 }
 
-function thread(f) {
-  // TODO: spawn thread and run f in it; return a handle for the thread
+function thread(shared, f) {
+  // TODO: spawn thread, share instances, and run f in it; return a handle for the thread
 }
 
 function wait(t) {
@@ -466,9 +466,11 @@ let rec of_command c cmd =
     of_assertion' c act "run" [] None ^ "\n"
   | Assertion ass ->
     of_assertion c ass ^ "\n"
-  | Thread (x_opt, cmds) ->
+  | Thread (x_opt, xs, cmds) ->
     "let " ^ current_var c.threads ^
-    " = thread(function () {" ^
+    " = thread([" ^
+    String.concat ", " (List.map (fun x -> "\"" ^ x.it ^ "\"") xs) ^
+    "], function () {" ^
     String.concat "" (List.map (of_command c) cmds) ^
     "});\n"
   | Wait x_opt ->

--- a/interpreter/script/js.ml
+++ b/interpreter/script/js.ml
@@ -163,6 +163,14 @@ function match_result(actual, expected) {
       };
   }
 }
+
+function thread(f) {
+  // TODO: spawn thread and run f in it; return a handle for the thread
+}
+
+function wait(t) {
+  // TODO: wait for thread t to terminate
+}
 |}
 
 
@@ -393,6 +401,7 @@ let of_action mods act =
       Some (of_wrapper mods x_opt name (get gt), [t])
     | _ -> None
     )
+  | Eval -> assert false
 
 let of_assertion' mods act name args wrapper_opt =
   let act_js, act_wrapper_opt = of_action mods act in
@@ -447,10 +456,11 @@ let of_command mods cmd =
   | Thread (x_opt, cmds) ->
     (* TODO *)
     assert false
-  | Wait x ->
+  | Wait x_opt ->
     (* TODO *)
     assert false
-  | Meta _ -> assert false
+  | Meta _
+  | Implicit _ -> assert false
 
 let of_script scr =
   (if !Flags.harness then harness else "") ^

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -252,7 +252,7 @@ let rec type_of_result r =
   match r.it with
   | LitResult v -> Values.type_of v.it
   | NanResult n -> Values.type_of n.it
-  | OneofResult rs -> type_of_result (List.hd rs)
+  | EitherResult rs -> type_of_result (List.hd rs)
 
 let rec string_of_result r =
   match r.it with
@@ -262,7 +262,7 @@ let rec string_of_result r =
     | Values.I32 _ | Values.I64 _ -> assert false
     | Values.F32 n | Values.F64 n -> string_of_nan n
     )
-  | OneofResult rs ->
+  | EitherResult rs ->
     "(" ^ String.concat " | " (List.map string_of_result rs) ^ ")"
 
 let string_of_results = function
@@ -412,7 +412,7 @@ let rec match_result at v r =
       Int64.logand (F64.to_bits z) pos_nan = pos_nan
     | _, _ -> false
     )
-  | OneofResult rs -> List.exists (match_result at v) rs
+  | EitherResult rs -> List.exists (match_result at v) rs
 
 let assert_result at got expect =
   if

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -250,9 +250,11 @@ let string_of_nan = function
 
 let rec type_of_result r =
   match r.it with
-  | LitResult v -> Values.type_of v.it
-  | NanResult n -> Values.type_of n.it
-  | EitherResult rs -> type_of_result (List.hd rs)
+  | LitResult v -> Some (Values.type_of v.it)
+  | NanResult n -> Some (Values.type_of n.it)
+  | EitherResult rs ->
+    let ts = List.map type_of_result rs in
+    List.fold_left (fun t1 t2 -> if t1 = t2 then t1 else None) (List.hd ts) ts
 
 let rec string_of_result r =
   match r.it with
@@ -269,10 +271,18 @@ let string_of_results = function
   | [r] -> string_of_result r
   | rs -> "[" ^ String.concat " " (List.map string_of_result rs) ^ "]"
 
+let string_of_value_type_opt = function
+  | Some t -> Types.string_of_value_type t
+  | None -> "?"
+
+let string_of_value_type_opts = function
+  | [t] -> string_of_value_type_opt t
+  | ts -> "[" ^ String.concat " " (List.map string_of_value_type_opt ts) ^ "]"
+
 let print_results rs =
   let ts = List.map type_of_result rs in
   Printf.printf "%s : %s\n"
-    (string_of_results rs) (Types.string_of_value_types ts);
+    (string_of_results rs) (string_of_value_type_opts ts);
   flush_all ()
 
 

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -576,14 +576,7 @@ let rec run_command c cmd : command list =
 and run_meta c cmd : meta list =
   match cmd.it with
   | Script (x_opt, [], quote) ->
-    bind c.scripts None (List.rev quote);
-    bind c.scripts x_opt (lookup_script c None cmd.at);
-    if x_opt <> None then begin
-      bind c.modules x_opt (lookup_module c None cmd.at);
-      if not !Flags.dry then begin
-        bind c.instances x_opt (lookup_instance c None cmd.at)
-      end
-    end;
+    bind c.scripts x_opt (List.rev quote);
     []
 
   | Script (x_opt, cmd::cmds, quote) ->
@@ -596,6 +589,10 @@ and run_meta c cmd : meta list =
     (try if not (input_file file ((:=) script)) then
       Abort.error cmd.at "aborting"
     with Sys_error msg -> IO.error cmd.at msg);
+    (match !script with
+    | [{it = Module (None, def); at}] -> script := [Module (x_opt, def) @@ at]
+    | _ -> ()
+    );
     [Script (x_opt, !script, []) @@ cmd.at]
 
   | Output (x_opt, Some file) ->

--- a/interpreter/script/run.mli
+++ b/interpreter/script/run.mli
@@ -1,4 +1,4 @@
-type config
+type context
 
 exception Abort of Source.region * string
 exception Assert of Source.region * string
@@ -6,8 +6,8 @@ exception IO of Source.region * string
 
 val trace : string -> unit
 
-val config : unit -> config
+val context : unit -> context
 
-val run_string : config -> string -> bool
-val run_file : config -> string -> bool
-val run_stdin : config -> unit
+val run_string : context -> string -> bool
+val run_file : context -> string -> bool
+val run_stdin : context -> unit

--- a/interpreter/script/run.mli
+++ b/interpreter/script/run.mli
@@ -1,9 +1,13 @@
+type config
+
 exception Abort of Source.region * string
 exception Assert of Source.region * string
 exception IO of Source.region * string
 
 val trace : string -> unit
 
-val run_string : string -> bool
-val run_file : string -> bool
-val run_stdin : unit -> unit
+val config : unit -> config
+
+val run_string : config -> string -> bool
+val run_file : config -> string -> bool
+val run_stdin : config -> unit

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -10,6 +10,7 @@ type action = action' Source.phrase
 and action' =
   | Invoke of var option * Ast.name * Ast.literal list
   | Get of var option * Ast.name
+  | Eval
 
 type nanop = nanop' Source.phrase
 and nanop' = (unit, unit, nan, nan) Values.op
@@ -40,12 +41,13 @@ and command' =
   | Thread of var option * command list
   | Wait of var option
   | Meta of meta
+  | Implicit of command
 
 and meta = meta' Source.phrase
 and meta' =
   | Input of var option * string
   | Output of var option * string option
-  | Script of var option * script
+  | Script of var option * script * command list
 
 and script = command list
 

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -20,7 +20,7 @@ type result = result' Source.phrase
 and result' =
   | LitResult of Ast.literal
   | NanResult of nanop
-  | OneofResult of result list
+  | EitherResult of result list
 
 type assertion = assertion' Source.phrase
 and assertion' =

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -41,13 +41,12 @@ and command' =
   | Thread of var option * var list * command list
   | Wait of var option
   | Meta of meta
-  | Implicit of command
 
 and meta = meta' Source.phrase
 and meta' =
   | Input of var option * string
   | Output of var option * string option
-  | Script of var option * script * command list
+  | Script of var option * script * script * command list
 
 and script = command list
 

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -46,7 +46,12 @@ and meta = meta' Source.phrase
 and meta' =
   | Input of var option * string
   | Output of var option * string option
-  | Script of var option * script * script * command list
+  | Script of var option * (* s1 : *) script * (* s2 : *) script * (* q : *) script
+    (* s1 @ s2 is remaining script to run
+     * q is script quote of original commands with inputs expanded (reversed)
+     * s1 contains reduced commands that must not be quoted
+     * s2 contains original commands that still need quoting
+     *)
 
 and script = command list
 

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -10,7 +10,6 @@ type action = action' Source.phrase
 and action' =
   | Invoke of var option * Ast.name * Ast.literal list
   | Get of var option * Ast.name
-  | Join of var
 
 type nanop = nanop' Source.phrase
 and nanop' = (unit, unit, nan, nan) Values.op
@@ -20,6 +19,7 @@ type result = result' Source.phrase
 and result' =
   | LitResult of Ast.literal
   | NanResult of nanop
+  | OneofResult of result list
 
 type assertion = assertion' Source.phrase
 and assertion' =
@@ -37,7 +37,8 @@ and command' =
   | Register of Ast.name * var option
   | Action of action
   | Assertion of assertion
-  | Thread of var option * action
+  | Thread of var option * command list
+  | Wait of var
   | Meta of meta
 
 and meta = meta' Source.phrase

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -38,7 +38,7 @@ and command' =
   | Register of Ast.name * var option
   | Action of action
   | Assertion of assertion
-  | Thread of var option * command list
+  | Thread of var option * var list * command list
   | Wait of var option
   | Meta of meta
   | Implicit of command

--- a/interpreter/script/script.ml
+++ b/interpreter/script/script.ml
@@ -38,7 +38,7 @@ and command' =
   | Action of action
   | Assertion of assertion
   | Thread of var option * command list
-  | Wait of var
+  | Wait of var option
   | Meta of meta
 
 and meta = meta' Source.phrase

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -32,6 +32,17 @@ let packed_size = function
   | Pack16 -> 2
   | Pack32 -> 4
 
+let shared_func_type (FuncType _) = Unshared
+let shared_table_type (TableType _) = Unshared
+let shared_memory_type (MemoryType (_, shared)) = shared
+let shared_global_type (GlobalType _) = Unshared
+
+let shared_extern_type = function
+  | ExternFuncType ft -> shared_func_type ft
+  | ExternTableType tt -> shared_table_type tt
+  | ExternMemoryType mt -> shared_memory_type mt
+  | ExternGlobalType gt -> shared_global_type gt
+
 
 (* Subtyping *)
 

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -538,7 +538,7 @@ let rec command mode cmd =
   | Thread (x_opt, xs, cmds) ->
     [Node ("thread" ^ var_opt x_opt,
       List.map (fun x -> Node ("shared", [Node ("module " ^ x.it, [])])) xs @
-      List.concat_map (command mode) cmds)
+      Lib.List.concat_map (command mode) cmds)
     ]
   | Wait x_opt -> [Node ("wait" ^ var_opt x_opt, [])]
   | Meta met -> [meta mode met]

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -542,7 +542,6 @@ let rec command mode cmd =
     ]
   | Wait x_opt -> [Node ("wait" ^ var_opt x_opt, [])]
   | Meta met -> [meta mode met]
-  | Implicit cmd' -> [Node ("implicit", command mode cmd')]
 
 and meta mode met =
   match met.it with
@@ -552,7 +551,7 @@ and meta mode met =
     Node ("output" ^ var_opt x_opt, [Atom (" \"" ^ file ^ "\"")])
   | Output (x_opt, None) ->
     Node ("output" ^ var_opt x_opt, [])
-  | Script (x_opt, _, _) ->
+  | Script (x_opt, _, _, _) ->
     Node ("script" ^ var_opt x_opt, [Atom "..."])
 
 let script mode scr = Lib.List.concat_map (command mode) scr

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -506,7 +506,7 @@ let rec result mode res =
     | Values.F32 n -> Node ("f32.const " ^ nan n, [])
     | Values.F64 n -> Node ("f64.const " ^ nan n, [])
     )
-  | OneofResult ress -> Node ("oneof", List.map (result mode) ress)
+  | EitherResult ress -> Node ("either", List.map (result mode) ress)
 
 let assertion mode ass =
   match ass.it with

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -535,7 +535,7 @@ let rec command mode cmd =
   | Assertion ass -> assertion mode ass
   | Thread (x_opt, cmds) ->
     [Node ("thread " ^ var_opt x_opt, List.concat_map (command mode) cmds)]
-  | Wait x -> [Node ("wait " ^ x.it, [])]
+  | Wait x_opt -> [Node ("wait " ^ var_opt x_opt, [])]
   | Meta _ -> assert false
 
 let script mode scr = Lib.List.concat_map (command mode) scr

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -535,8 +535,11 @@ let rec command mode cmd =
   | Register (n, x_opt) -> [Node ("register " ^ name n ^ var_opt x_opt, [])]
   | Action act -> [action mode act]
   | Assertion ass -> assertion mode ass
-  | Thread (x_opt, cmds) ->
-    [Node ("thread" ^ var_opt x_opt, List.concat_map (command mode) cmds)]
+  | Thread (x_opt, xs, cmds) ->
+    [Node ("thread" ^ var_opt x_opt,
+      List.map (fun x -> Node ("shared", [Node ("module " ^ x.it, [])])) xs @
+      List.concat_map (command mode) cmds)
+    ]
   | Wait x_opt -> [Node ("wait" ^ var_opt x_opt, [])]
   | Meta met -> [meta mode met]
   | Implicit cmd' -> [Node ("implicit", command mode cmd')]

--- a/interpreter/text/arrange.mli
+++ b/interpreter/text/arrange.mli
@@ -3,4 +3,5 @@ open Sexpr
 val instr : Ast.instr -> sexpr
 val func : Ast.func -> sexpr
 val module_ : Ast.module_ -> sexpr
+val command : [`Textual | `Binary] -> Script.command -> sexpr list
 val script : [`Textual | `Binary] -> Script.script -> sexpr list

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -451,7 +451,7 @@ rule token = parse
   | "assert_exhaustion" { ASSERT_EXHAUSTION }
   | "nan:canonical" { NAN Script.CanonicalNan }
   | "nan:arithmetic" { NAN Script.ArithmeticNan }
-  | "oneof" { ONEOF }
+  | "either" { EITHER }
   | "input" { INPUT }
   | "output" { OUTPUT }
 

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -440,7 +440,7 @@ rule token = parse
   | "script" { SCRIPT }
   | "register" { REGISTER }
   | "thread" { THREAD }
-  | "join" { JOIN }
+  | "wait" { WAIT }
   | "invoke" { INVOKE }
   | "get" { GET }
   | "assert_malformed" { ASSERT_MALFORMED }
@@ -451,6 +451,7 @@ rule token = parse
   | "assert_exhaustion" { ASSERT_EXHAUSTION }
   | "nan:canonical" { NAN Script.CanonicalNan }
   | "nan:arithmetic" { NAN Script.ArithmeticNan }
+  | "oneof" { ONEOF }
   | "input" { INPUT }
   | "output" { OUTPUT }
 

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -176,10 +176,10 @@ let inline_type_explicit (c : context) x ft at =
 %token FUNC START TYPE PARAM RESULT LOCAL GLOBAL
 %token TABLE ELEM MEMORY DATA OFFSET IMPORT EXPORT TABLE
 %token MODULE BIN QUOTE
-%token SCRIPT REGISTER THREAD JOIN INVOKE GET
+%token SCRIPT REGISTER THREAD WAIT INVOKE GET
 %token ASSERT_MALFORMED ASSERT_INVALID ASSERT_SOFT_INVALID ASSERT_UNLINKABLE
 %token ASSERT_RETURN ASSERT_TRAP ASSERT_EXHAUSTION
-%token NAN
+%token NAN ONEOF
 %token INPUT OUTPUT
 %token EOF
 
@@ -875,8 +875,6 @@ action :
     { Invoke ($3, $4, $5) @@ at () }
   | LPAR GET module_var_opt name RPAR
     { Get ($3, $4) @@ at() }
-  | LPAR JOIN thread_var RPAR
-    { Join $3 @@ at () }
 
 assertion :
   | LPAR ASSERT_MALFORMED script_module STRING RPAR
@@ -900,7 +898,8 @@ cmd :
   | assertion { Assertion $1 @@ at () }
   | script_module { Module (fst $1, snd $1) @@ at () }
   | LPAR REGISTER name module_var_opt RPAR { Register ($3, $4) @@ at () }
-  | LPAR THREAD thread_var_opt action RPAR { Thread ($3, $4) @@ at () }
+  | LPAR THREAD thread_var_opt cmd_list RPAR { Thread ($3, $4) @@ at () }
+  | LPAR WAIT thread_var RPAR { Wait $3 @@ at () }
   | meta { Meta $1 @@ at () }
 
 cmd_list :
@@ -923,6 +922,7 @@ const_list :
 result :
   | const { LitResult $1 @@ at () }
   | LPAR CONST NAN RPAR { NanResult (nanop $2 ($3 @@ ati 3)) @@ at () }
+  | LPAR ONEOF result result_list RPAR { OneofResult ($3 :: $4) @@ at () }
 
 result_list :
   | /* empty */ { [] }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -854,10 +854,7 @@ inline_module1 :  /* Sugar */
 
 thread_var_opt :
   | /* empty */ { None }
-  | thread_var { Some $1 }
-
-thread_var :
-  | VAR { $1 @@ at () }
+  | VAR { Some ($1 @@ at ()) }
 
 script_var_opt :
   | /* empty */ { None }
@@ -894,13 +891,19 @@ cmd :
   | assertion { Assertion $1 @@ at () }
   | script_module { Module (fst $1, snd $1) @@ at () }
   | LPAR REGISTER name module_var_opt RPAR { Register ($3, $4) @@ at () }
-  | LPAR THREAD thread_var_opt cmd_list RPAR { Thread ($3, $4) @@ at () }
+  | LPAR THREAD thread_var_opt shared_cmd_list RPAR
+    { let xs, cs = $4 in Thread ($3, xs, cs) @@ at () }
   | LPAR WAIT thread_var_opt RPAR { Wait $3 @@ at () }
   | meta { Meta $1 @@ at () }
 
 cmd_list :
   | /* empty */ { [] }
   | cmd cmd_list { $1 :: $2 }
+
+shared_cmd_list :
+  | cmd_list { [], $1 }
+  | LPAR SHARED LPAR MODULE VAR RPAR RPAR shared_cmd_list
+    { let xs, cs = $8 in ($5 @@ ati 5) :: xs, cs }
 
 meta :
   | LPAR SCRIPT script_var_opt cmd_list RPAR { Script ($3, $4, []) @@ at () }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -907,7 +907,7 @@ cmd_list :
   | cmd cmd_list { $1 :: $2 }
 
 meta :
-  | LPAR SCRIPT script_var_opt cmd_list RPAR { Script ($3, $4) @@ at () }
+  | LPAR SCRIPT script_var_opt cmd_list RPAR { Script ($3, $4, []) @@ at () }
   | LPAR INPUT script_var_opt STRING RPAR { Input ($3, $4) @@ at () }
   | LPAR OUTPUT script_var_opt STRING RPAR { Output ($3, Some $4) @@ at () }
   | LPAR OUTPUT script_var_opt RPAR { Output ($3, None) @@ at () }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -179,7 +179,7 @@ let inline_type_explicit (c : context) x ft at =
 %token SCRIPT REGISTER THREAD WAIT INVOKE GET
 %token ASSERT_MALFORMED ASSERT_INVALID ASSERT_SOFT_INVALID ASSERT_UNLINKABLE
 %token ASSERT_RETURN ASSERT_TRAP ASSERT_EXHAUSTION
-%token NAN ONEOF
+%token NAN EITHER
 %token INPUT OUTPUT
 %token EOF
 
@@ -889,10 +889,6 @@ assertion :
   | LPAR ASSERT_TRAP action STRING RPAR { AssertTrap ($3, $4) @@ at () }
   | LPAR ASSERT_EXHAUSTION action STRING RPAR { AssertExhaustion ($3, $4) @@ at () }
 
-assertion_list :
-  | /* empty */ { [] }
-  | assertion assertion_list { $1 :: $2 }
-
 cmd :
   | action { Action $1 @@ at () }
   | assertion { Assertion $1 @@ at () }
@@ -922,7 +918,7 @@ const_list :
 result :
   | const { LitResult $1 @@ at () }
   | LPAR CONST NAN RPAR { NanResult (nanop $2 ($3 @@ ati 3)) @@ at () }
-  | LPAR ONEOF result result_list RPAR { OneofResult ($3 :: $4) @@ at () }
+  | LPAR EITHER result result_list RPAR { EitherResult ($3 :: $4) @@ at () }
 
 result_list :
   | /* empty */ { [] }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -906,7 +906,7 @@ shared_cmd_list :
     { let xs, cs = $8 in ($5 @@ ati 5) :: xs, cs }
 
 meta :
-  | LPAR SCRIPT script_var_opt cmd_list RPAR { Script ($3, $4, []) @@ at () }
+  | LPAR SCRIPT script_var_opt cmd_list RPAR { Script ($3, [], $4, []) @@ at () }
   | LPAR INPUT script_var_opt STRING RPAR { Input ($3, $4) @@ at () }
   | LPAR OUTPUT script_var_opt STRING RPAR { Output ($3, Some $4) @@ at () }
   | LPAR OUTPUT script_var_opt RPAR { Output ($3, None) @@ at () }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -899,7 +899,7 @@ cmd :
   | script_module { Module (fst $1, snd $1) @@ at () }
   | LPAR REGISTER name module_var_opt RPAR { Register ($3, $4) @@ at () }
   | LPAR THREAD thread_var_opt cmd_list RPAR { Thread ($3, $4) @@ at () }
-  | LPAR WAIT thread_var RPAR { Wait $3 @@ at () }
+  | LPAR WAIT thread_var_opt RPAR { Wait $3 @@ at () }
   | meta { Meta $1 @@ at () }
 
 cmd_list :

--- a/interpreter/text/print.ml
+++ b/interpreter/text/print.ml
@@ -1,5 +1,7 @@
 let instr oc width e = Sexpr.output oc width (Arrange.instr e)
 let func oc width f = Sexpr.output oc width (Arrange.func f)
 let module_ oc width m = Sexpr.output oc width (Arrange.module_ m)
+let command oc width mode s =
+  List.iter (Sexpr.output oc width) (Arrange.command mode s)
 let script oc width mode s =
   List.iter (Sexpr.output oc width) (Arrange.script mode s)

--- a/interpreter/text/print.mli
+++ b/interpreter/text/print.mli
@@ -1,4 +1,5 @@
 val instr : out_channel -> int -> Ast.instr -> unit
 val func : out_channel -> int -> Ast.func -> unit
 val module_ : out_channel -> int -> Ast.module_ -> unit
+val command : out_channel -> int -> [`Textual | `Binary] -> Script.command -> unit
 val script : out_channel -> int -> [`Textual | `Binary] -> Script.script -> unit

--- a/interpreter/util/lib.ml
+++ b/interpreter/util/lib.ml
@@ -76,6 +76,17 @@ struct
     | n, _::xs' when n > 0 -> drop (n - 1) xs'
     | _ -> failwith "drop"
 
+  let rec split n xs =
+    match n, xs with
+    | 0, _ -> [], xs
+    | n, x::xs' when n > 0 -> let ys, zs = split (n - 1) xs' in x::ys, zs
+    | _ -> failwith "split"
+
+  let extract n xs =
+    match split n xs with
+    | ys, z::zs -> ys, z, zs
+    | _ -> failwith "extract"
+
   let rec last = function
     | x::[] -> x
     | _::xs -> last xs
@@ -137,6 +148,13 @@ struct
     | 0l, _ -> xs
     | n, _::xs' when n > 0l -> drop (Int32.sub n 1l) xs'
     | _ -> failwith "drop"
+
+  let rec split n xs =
+    match n, xs with
+    | 0l, _ -> [], xs
+    | n, x::xs' when n > 0l ->
+      let ys, zs = split (Int32.sub n 1l) xs' in x::ys, zs
+    | _ -> failwith "split"
 end
 
 module Array32 =
@@ -195,4 +213,8 @@ struct
   let app f = function
     | Some x -> f x
     | None -> ()
+
+  let fold x f = function
+    | Some y -> f y
+    | None -> x
 end

--- a/interpreter/util/lib.mli
+++ b/interpreter/util/lib.mli
@@ -14,6 +14,8 @@ sig
   val table : int -> (int -> 'a) -> 'a list
   val take : int -> 'a list -> 'a list (* raises Failure *)
   val drop : int -> 'a list -> 'a list (* raises Failure *)
+  val split : int -> 'a list -> 'a list * 'a list (* raises Failure *)
+  val extract : int -> 'a list -> 'a list * 'a * 'a list (* raises Failure *)
 
   val last : 'a list -> 'a (* raises Failure *)
   val split_last : 'a list -> 'a list * 'a (* raises Failure *)
@@ -31,6 +33,7 @@ sig
   val nth : 'a list -> int32 -> 'a (* raises Failure *)
   val take : int32 -> 'a list -> 'a list (* raises Failure *)
   val drop : int32 -> 'a list -> 'a list (* raises Failure *)
+  val split : int32 -> 'a list -> 'a list * 'a list (* raises Failure *)
 end
 
 module Array32 :
@@ -61,6 +64,7 @@ sig
   val get : 'a option -> 'a -> 'a
   val map : ('a -> 'b) -> 'a option -> 'b option
   val app : ('a -> unit) -> 'a option -> unit
+  val fold : 'b -> ('a -> 'b) -> 'a option -> 'b
 end
 
 module Int :

--- a/test/core/thread.wast
+++ b/test/core/thread.wast
@@ -21,7 +21,7 @@
       (i32.load (i32.const 0))
     )
   )
-  (assert_return (invoke "run") (oneof (i32.const 0) (i32.const 42)))
+  (assert_return (invoke "run") (either (i32.const 0) (i32.const 42)))
 )
 
 (wait $T1)

--- a/test/core/thread.wast
+++ b/test/core/thread.wast
@@ -1,0 +1,28 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+
+(thread $T1
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 10 shared)
+    (func (export "run")
+      (i32.store (i32.const 0) (i32.const 42))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run") (result i32)
+      (i32.load (i32.const 0))
+    )
+  )
+  (assert_return (invoke "run") (oneof (i32.const 0) (i32.const 42)))
+)
+
+(wait $T1)
+(wait $T2)

--- a/test/core/thread.wast
+++ b/test/core/thread.wast
@@ -2,7 +2,7 @@
   (memory (export "shared") 1 1 shared)
 )
 
-(thread $T1
+(thread $T1 (shared (module $Mem))
   (register "mem" $Mem)
   (module
     (memory (import "mem" "shared") 1 10 shared)
@@ -13,7 +13,7 @@
   (invoke "run")
 )
 
-(thread $T2
+(thread $T2 (shared (module $Mem))
   (register "mem" $Mem)
   (module
     (memory (import "mem" "shared") 1 1 shared)


### PR DESCRIPTION
This adds threading support to the interpreter:

* Add threads to evaluator and script runner, with randomised execution.
* Add `thread` and `wait` script commands for spawning and joining threads.
* Add `either` result pattern for testing non-deterministic results.
* Extend JS harness with new functions `thread` and `wait` (not yet fleshed out).
* Add a trivial test.
* Added command line flags for setting non-determinism random seed.

This includes scripting functionality as discussed in #163. However, I decided to make sharing more explicit with `(sharing ...)` annotations in a thread definition, because it's more readable, avoids funny errors, and it's probably gonna be easier to implement in the JS converter that way. See test for how it's used.

Sorry for the large PR, this required more refactoring than I anticipated. In particular, the whole script runner had to effectively be transformed from big step to small step. Similarly, Eval.invoke and Eval.init needed to become small steps.