### PR TITLE
Fix error in Web embedding desc for atomic.notify

### DIFF
--- a/proposals/threads/Overview.md
+++ b/proposals/threads/Overview.md
@@ -436,8 +436,7 @@ For the web embedding, `memory.atomic.notify` is equivalent in behavior to execu
 1. Let `memory` be a `WebAssembly.Memory` object for this module.
 1. Let `buffer` be `memory`([`Get`][](`memory`, `"buffer"`)).
 1. Let `int32array` be [`Int32Array`][](`buffer`).
-1. Let `fcount` be `count` if `count` is >= 0, otherwise `∞`.
-1. Let `result` be [`Atomics.notify`][](`int32array`, `address`, `fcount`).
+1. Let `result` be [`Atomics.notify`][](`int32array`, `address`, `count`).
 1. Return `result` converted to an `i32`.
 
 ## Fence operator


### PR DESCRIPTION
ref: https://github.com/WebAssembly/binaryen/issues/4393

In https://github.com/WebAssembly/threads/pull/110 we changed the `count` argument of `atomic.notify` so that it is treated as an unsigned `i32`. Previous to this change, it was interpreted as a signed `i32`, with negative numbers signalling that all threads should be woken. This part of the overview wasn't fully updated - fixing this now.