### PR TITLE
Soften language for `notify` on unshared memories

### DIFF
--- a/proposals/threads/Overview.md
+++ b/proposals/threads/Overview.md
@@ -416,9 +416,10 @@ Similarly, `memory.atomic.wait64` is equivalent in behavior to executing the fol
 The notify operator takes two operands: an address operand and a count as an
 unsigned `i32`. The operation will notify as many waiters as are waiting on the
 same effective address, up to the maximum as specified by `count`. The operator
-returns the number of waiters that were woken as an unsigned `i32`. Note that if
-the notify operator is used with an unshared linear memory, the number of
-waiters will always be zero.
+returns the number of waiters that were woken as an unsigned `i32`. Note that
+there is no way to create a waiter on unshared linear memory from within Wasm,
+so if the notify operator is used with an unshared linear memory, the number of
+waiters will always be zero unless the host has created such a waiter.
 
   * `memory.atomic.notify`: notify `count` threads waiting on the given address via `memory.atomic.wait32` or `memory.atomic.wait64`
 


### PR DESCRIPTION
Since #144, we've specified that `memory.atomic.notify` is allowed to be executed on unshared memories, but always returns 0 since it is impossible for there to be anything waiting on an unshared memory since all variations of the wait instructions in Wasm and JS trap or throw exceptions on unshared memories. However, I realized recently that there is no technical reason why [`Atomics.waitAsync`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync) shouldn't be able to wait on an unshared memory. Because `Atomics.waitAsync` returns a promise rather than blocking, it can in principle be used to synchronize between multiple asynchronous tasks in flight concurrently in the same JS context, and now that [JSPI](https://github.com/WebAssembly/js-promise-integration/blob/main/proposals/js-promise-integration/Overview.md) is becoming more real, this actually might be a useful thing to do. In particular `Atomics.waitAsync` could be used to build suspending versions of mutexes and condition variables to synchronize between threads running as different asynchronous tasks within a single JS context.

Actually realizing this vision of asynchronous threading with JSPI on top of `Atomics.waitAsync` requires changes on the JS side to allow `Atomics.waitAsync` and `Atomics.notify` to be used on unshared ArrayBuffers, but in the meantime we can prepare for that change on the Wasm side by softening the language stating that `memory.atomic.notify` unconditionally returns 0 for unshared memories.

cc @syg