### PR TITLE
Fix some typos in `*.wast` tests

### DIFF
--- a/test/core/threads/LB.wast
+++ b/test/core/threads/LB.wast
@@ -41,7 +41,7 @@
 (wait $T2)
 
 (module $Check
-  (memory (import "mem" "shared") 1 1 shared)
+  (memory (import "Mem" "shared") 1 1 shared)
 
   (func (export "check") (result i32)
     (local i32 i32)
@@ -53,7 +53,7 @@
     ;; allowed results: (L_0 = 0 || L_0 = 1) && (L_1 = 0 || L_1 = 1)
 
     (i32.or (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 0) (i32.const 0)))
-    (i32.or (i32.eq (local.get 1) (i32.const 1)) (i32.eq (local.get 0) (i32.const 0)))
+    (i32.or (i32.eq (local.get 1) (i32.const 1)) (i32.eq (local.get 1) (i32.const 0)))
     (i32.and)
     (return)
   )

--- a/test/core/threads/LB_atomic.wast
+++ b/test/core/threads/LB_atomic.wast
@@ -41,7 +41,7 @@
 (wait $T2)
 
 (module $Check
-  (memory (import "mem" "shared") 1 1 shared)
+  (memory (import "Mem" "shared") 1 1 shared)
 
   (func (export "check") (result i32)
     (local i32 i32)

--- a/test/core/threads/MP.wast
+++ b/test/core/threads/MP.wast
@@ -38,7 +38,7 @@
 (wait $T2)
 
 (module $Check
-  (memory (import "mem" "shared") 1 1 shared)
+  (memory (import "Mem" "shared") 1 1 shared)
 
   (func (export "check") (result i32)
     (local i32 i32)
@@ -50,7 +50,7 @@
     ;; allowed results: (L_0 = 0 || L_0 = 1) && (L_1 = 0 || L_1 = 42)
 
     (i32.or (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 0) (i32.const 0)))
-    (i32.or (i32.eq (local.get 1) (i32.const 42)) (i32.eq (local.get 0) (i32.const 0)))
+    (i32.or (i32.eq (local.get 1) (i32.const 42)) (i32.eq (local.get 1) (i32.const 0)))
     (i32.and)
     (return)
   )

--- a/test/core/threads/MP_atomic.wast
+++ b/test/core/threads/MP_atomic.wast
@@ -38,7 +38,7 @@
 (wait $T2)
 
 (module $Check
-  (memory (import "mem" "shared") 1 1 shared)
+  (memory (import "Mem" "shared") 1 1 shared)
 
   (func (export "check") (result i32)
     (local i32 i32)

--- a/test/core/threads/MP_wait.wast
+++ b/test/core/threads/MP_wait.wast
@@ -38,7 +38,7 @@
 (wait $T2)
 
 (module $Check
-  (memory (import "mem" "shared") 1 1 shared)
+  (memory (import "Mem" "shared") 1 1 shared)
 
   (func (export "check") (result i32)
     (local i32 i32)

--- a/test/core/threads/SB.wast
+++ b/test/core/threads/SB.wast
@@ -41,7 +41,7 @@
 (wait $T2)
 
 (module $Check
-  (memory (import "mem" "shared") 1 1 shared)
+  (memory (import "Mem" "shared") 1 1 shared)
 
   (func (export "check") (result i32)
     (local i32 i32)
@@ -53,7 +53,7 @@
     ;; allowed results: (L_0 = 0 || L_0 = 1) && (L_1 = 0 || L_1 = 1)
 
     (i32.or (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 0) (i32.const 0)))
-    (i32.or (i32.eq (local.get 1) (i32.const 1)) (i32.eq (local.get 0) (i32.const 0)))
+    (i32.or (i32.eq (local.get 1) (i32.const 1)) (i32.eq (local.get 1) (i32.const 0)))
     (i32.and)
     (return)
   )

--- a/test/core/threads/SB_atomic.wast
+++ b/test/core/threads/SB_atomic.wast
@@ -41,7 +41,7 @@
 (wait $T2)
 
 (module $Check
-  (memory (import "mem" "shared") 1 1 shared)
+  (memory (import "Mem" "shared") 1 1 shared)
 
   (func (export "check") (result i32)
     (local i32 i32)


### PR DESCRIPTION
Most of the tests' `$Check` modules imported from `"mem"` which was failing when I integrated this into Wasmtime. This may very well be a bug in my understanding of the `*.wast` format, however, but currently via `(module $Mem ...)` that defines the name `"Mem"` for modules to use but not `"mem"`. If this is supposed to work as-is I can update Wasmtime instead.

Additionally some tests' comments were checking `L_1` but were actually checking against `local.get 0` so I've updated them to `local.get 1` which fixed some failing tests on Wasmtime.