### PR TITLE
Remove duplicate (broken) definition of `assert_ArrayBuffer`

### DIFF
--- a/test/js-api/memory/grow.any.js
+++ b/test/js-api/memory/grow.any.js
@@ -1,30 +1,6 @@
 // META: global=window,dedicatedworker,jsshell
 // META: script=/wasm/jsapi/memory/assertions.js
 
-function assert_ArrayBuffer(actual, expected, message) {
-  // https://github.com/WebAssembly/spec/issues/840
-  const bufferType = expected.shared ? self.SharedArrayBuffer : ArrayBuffer;
-  assert_equals(Object.getPrototypeOf(actual), bufferType.prototype,
-                `${message}: prototype`);
-  if (expected.detached) {
-    // https://github.com/tc39/ecma262/issues/678
-    let byteLength;
-    try {
-      byteLength = actual.byteLength;
-    } catch (e) {
-      byteLength = 0;
-    }
-    assert_equals(byteLength, 0, `${message}: detached size`);
-  } else {
-    assert_equals(actual.byteLength, 0x10000 * expected.size, `${message}: size`);
-    if (expected.size > 0) {
-      const array = new Uint8Array(actual);
-      assert_equals(array[0], 0, `${message}: first element`);
-      assert_equals(array[array.byteLength - 1], 0, `${message}: last element`);
-    }
-  }
-}
-
 test(() => {
   const argument = { "initial": 0 };
   const memory = new WebAssembly.Memory(argument);


### PR DESCRIPTION
This was removed from the upstream test in
https://github.com/WebAssembly/spec/commit/cc2d59bd56e5342e3c1834a7699915f8b67fc29c.

The `assert_ArrayBuffer` helper is now defined in the `assertions.js` file. The version there does not have the problem with `self`.

This problem was uncovered when importing the threads JS tests into V8, see https://crbug.com/449581914.