### PR TITLE
Fix proxy used in memory constructor test

### DIFF
--- a/test/js-api/memory/constructor.any.js
+++ b/test/js-api/memory/constructor.any.js
@@ -96,7 +96,18 @@ test(() => {
       assert_unreached(`Should not call [[HasProperty]] with ${x}`);
     },
     get(o, x) {
-      return 0;
+      // Due to the requirement not to supply both minimum and initial, we need to ignore one of them.
+      switch (x) {
+        case "shared":
+          return false;
+        case "initial":
+        case "maximum":
+          return 0;
+        case "address":
+          return "i32";
+        default:
+          return undefined;
+      }
     },
   });
   new WebAssembly.Memory(proxy);


### PR DESCRIPTION
Another targeted fix to make this test pass in V8. This was fixed upstream already, so alternatively we could rebase the whole repository.