### PR TITLE
[threads][test][js-api] Add tests for memory buffer integrity

### DIFF
--- a/test/js-api/memory/integrity.any.js
+++ b/test/js-api/memory/integrity.any.js
@@ -1,21 +1,25 @@
 // META: global=window,dedicatedworker,jsshell
 
 test(() => {
-  const memory = new WebAssembly.Memory({ "initial": 1, "maximum": 2, "shared": true });
+  const memory =
+      new WebAssembly.Memory({'initial': 1, 'maximum': 2, 'shared': true});
   const buffer = memory.buffer;
-  assert_true(Object.isFrozen(buffer), "Shared buffer should be frozen");
+  assert_true(Object.isFrozen(buffer), 'Shared buffer should be frozen');
   assert_throws_js(TypeError, () => {
-    "use strict";
+    'use strict';
     buffer.x = 1;
-  }, "Cannot add property to frozen shared buffer");
-}, "Shared memory buffer integrity");
+  }, 'Cannot add property to frozen shared buffer');
+}, 'Shared memory buffer integrity');
 
 test(() => {
-  const memory = new WebAssembly.Memory({ "initial": 1 });
+  const memory = new WebAssembly.Memory({'initial': 1});
   const buffer = memory.buffer;
-  assert_false(Object.isFrozen(buffer), "Non-shared buffer should not be frozen");
-  assert_true(Object.isExtensible(buffer), "Non-shared buffer should be extensible");
+  assert_false(
+      Object.isFrozen(buffer), 'Non-shared buffer should not be frozen');
+  assert_true(
+      Object.isExtensible(buffer), 'Non-shared buffer should be extensible');
   buffer.x = 1;
-  assert_equals(buffer.x, 1, "Should be able to add property to non-shared buffer");
+  assert_equals(
+      buffer.x, 1, 'Should be able to add property to non-shared buffer');
   delete buffer.x;
-}, "Non-shared memory buffer integrity");
+}, 'Non-shared memory buffer integrity');

--- a/test/js-api/memory/integrity.any.js
+++ b/test/js-api/memory/integrity.any.js
@@ -1,0 +1,21 @@
+// META: global=window,dedicatedworker,jsshell
+
+test(() => {
+  const memory = new WebAssembly.Memory({ "initial": 1, "maximum": 2, "shared": true });
+  const buffer = memory.buffer;
+  assert_true(Object.isFrozen(buffer), "Shared buffer should be frozen");
+  assert_throws_js(TypeError, () => {
+    "use strict";
+    buffer.x = 1;
+  }, "Cannot add property to frozen shared buffer");
+}, "Shared memory buffer integrity");
+
+test(() => {
+  const memory = new WebAssembly.Memory({ "initial": 1 });
+  const buffer = memory.buffer;
+  assert_false(Object.isFrozen(buffer), "Non-shared buffer should not be frozen");
+  assert_true(Object.isExtensible(buffer), "Non-shared buffer should be extensible");
+  buffer.x = 1;
+  assert_equals(buffer.x, 1, "Should be able to add property to non-shared buffer");
+  delete buffer.x;
+}, "Non-shared memory buffer integrity");


### PR DESCRIPTION
Add JS API tests for memory buffer integrity: Shared memory buffers should be frozen, while non-shared memory buffers should be extensible.