### PR TITLE
[test] Fix shared memory flag check in WasmModuleBuilder

### DIFF
--- a/test/js-api/wasm-module-builder.js
+++ b/test/js-api/wasm-module-builder.js
@@ -924,7 +924,7 @@ class WasmModuleBuilder {
             section.emit_u8(imp.mutable);
           } else if (imp.kind == kExternalMemory) {
             var has_max = (typeof imp.maximum) != "undefined";
-            var is_shared = (typeof imp.shared) != "undefined";
+            var is_shared = !!imp.shared;
             if (is_shared) {
               section.emit_u8(has_max ? 3 : 2); // flags
             } else {
@@ -979,7 +979,7 @@ class WasmModuleBuilder {
       binary.emit_section(kMemorySectionCode, section => {
         section.emit_u8(1);  // one memory entry
         const has_max = wasm.memory.max !== undefined;
-        const is_shared = wasm.memory.shared !== undefined;
+        const is_shared = !!wasm.memory.shared;
         // Emit flags (bit 0: reszeable max, bit 1: shared memory)
         if (is_shared) {
           section.emit_u8(has_max ? kSharedHasMaximumFlag : 2);


### PR DESCRIPTION
Using `wasm.memory.shared !== undefined` incorrectly treats `shared: false` as shared. This changes it to use a boolean cast.

This also matches the upstream V8 version of the module builder: https://source.chromium.org/chromium/chromium/src/+/main:v8/test/mjsunit/wasm/wasm-module-builder.js;l=2264;drc=4a369267cbda6cb3dc9858f90eb8dd9b61317111

This makes a test added in #250 actually pass.