### PR TITLE
Add atomic ordering param to memop

### DIFF
--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -550,7 +550,7 @@ let rec step_thread (t : thread) : thread * action =
             Plain (Const (I32 i @@ e.at));
             Plain (Const (k @@ e.at));
             Plain (Store
-              {ty = I32Type; align = 0; offset = 0l; pack = Some Pack8});
+              {ty = I32Type; align = 0; offset = 0l; pack = Some Pack8; ordering = Unordered});
             Plain (Const (I32 (I32.add i 1l) @@ e.at));
             Plain (Const (k @@ e.at));
             Plain (Const (I32 (I32.sub n 1l) @@ e.at));
@@ -567,9 +567,9 @@ let rec step_thread (t : thread) : thread * action =
             Plain (Const (I32 d @@ e.at));
             Plain (Const (I32 s @@ e.at));
             Plain (Load
-              {ty = I32Type; align = 0; offset = 0l; pack = Some (Pack8, ZX)});
+              {ty = I32Type; align = 0; offset = 0l; pack = Some (Pack8, ZX); ordering = Unordered});
             Plain (Store
-              {ty = I32Type; align = 0; offset = 0l; pack = Some Pack8});
+              {ty = I32Type; align = 0; offset = 0l; pack = Some Pack8; ordering = Unordered});
             Plain (Const (I32 (I32.add d 1l) @@ e.at));
             Plain (Const (I32 (I32.add s 1l) @@ e.at));
             Plain (Const (I32 (I32.sub n 1l) @@ e.at));
@@ -584,9 +584,9 @@ let rec step_thread (t : thread) : thread * action =
             Plain (Const (I32 d @@ e.at));
             Plain (Const (I32 s @@ e.at));
             Plain (Load
-              {ty = I32Type; align = 0; offset = 0l; pack = Some (Pack8, ZX)});
+              {ty = I32Type; align = 0; offset = 0l; pack = Some (Pack8, ZX); ordering = Unordered});
             Plain (Store
-              {ty = I32Type; align = 0; offset = 0l; pack = Some Pack8});
+              {ty = I32Type; align = 0; offset = 0l; pack = Some Pack8; ordering = Unordered});
           ], NoAction
 
       | MemoryInit x, Num (I32 n) :: Num (I32 s) :: Num (I32 d) :: vs' ->
@@ -602,7 +602,7 @@ let rec step_thread (t : thread) : thread * action =
             Plain (Const (I32 d @@ e.at));
             Plain (Const (I32 (I32.of_int_u (Char.code b)) @@ e.at));
             Plain (Store
-              {ty = I32Type; align = 0; offset = 0l; pack = Some Pack8});
+              {ty = I32Type; align = 0; offset = 0l; pack = Some Pack8; ordering = Unordered});
             Plain (Const (I32 (I32.add d 1l) @@ e.at));
             Plain (Const (I32 (I32.add s 1l) @@ e.at));
             Plain (Const (I32 (I32.sub n 1l) @@ e.at));

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -119,14 +119,17 @@ type vec_splatop = (V128Op.splatop) Values.vecop
 type vec_extractop = (V128Op.extractop) Values.vecop
 type vec_replaceop = (V128Op.replaceop) Values.vecop
 
-type ('t, 'p) memop = {ty : 't; align : int; offset : int32; pack : 'p}
-type loadop = (num_type, (pack_size * extension) option) memop
-type storeop = (num_type, pack_size option) memop
-type atomicop = (num_type, pack_size option) memop
+type ordering = SeqCst
+type unordered = Unordered
 
-type vec_loadop = (vec_type, (pack_size * vec_extension) option) memop
-type vec_storeop = (vec_type, unit) memop
-type vec_laneop = (vec_type, pack_size) memop * int
+type ('t, 'p, 'o) memop = {ty : 't; align : int; offset : int32; pack : 'p; ordering : 'o}
+type loadop = (num_type, (pack_size * extension) option, unordered) memop
+type storeop = (num_type, pack_size option, unordered) memop
+type atomicop = (num_type, pack_size option, ordering) memop
+
+type vec_loadop = (vec_type, (pack_size * vec_extension) option, unordered) memop
+type vec_storeop = (vec_type, unit, unordered) memop
+type vec_laneop = (vec_type, pack_size, unordered) memop * int
 
 
 (* Expressions *)

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -43,116 +43,116 @@ let table_copy x y = TableCopy (x, y)
 let table_init x y = TableInit (x, y)
 let elem_drop x = ElemDrop x
 
-let i32_load align offset = Load {ty = I32Type; align; offset; pack = None}
-let i64_load align offset = Load {ty = I64Type; align; offset; pack = None}
-let f32_load align offset = Load {ty = F32Type; align; offset; pack = None}
-let f64_load align offset = Load {ty = F64Type; align; offset; pack = None}
+let i32_load align offset = Load {ty = I32Type; align; offset; pack = None; ordering = Unordered}
+let i64_load align offset = Load {ty = I64Type; align; offset; pack = None; ordering = Unordered}
+let f32_load align offset = Load {ty = F32Type; align; offset; pack = None; ordering = Unordered}
+let f64_load align offset = Load {ty = F64Type; align; offset; pack = None; ordering = Unordered}
 let i32_load8_s align offset =
-  Load {ty = I32Type; align; offset; pack = Some (Pack8, SX)}
+  Load {ty = I32Type; align; offset; pack = Some (Pack8, SX); ordering = Unordered}
 let i32_load8_u align offset =
-  Load {ty = I32Type; align; offset; pack = Some (Pack8, ZX)}
+  Load {ty = I32Type; align; offset; pack = Some (Pack8, ZX); ordering = Unordered}
 let i32_load16_s align offset =
-  Load {ty = I32Type; align; offset; pack = Some (Pack16, SX)}
+  Load {ty = I32Type; align; offset; pack = Some (Pack16, SX); ordering = Unordered}
 let i32_load16_u align offset =
-  Load {ty = I32Type; align; offset; pack = Some (Pack16, ZX)}
+  Load {ty = I32Type; align; offset; pack = Some (Pack16, ZX); ordering = Unordered}
 let i64_load8_s align offset =
-  Load {ty = I64Type; align; offset; pack = Some (Pack8, SX)}
+  Load {ty = I64Type; align; offset; pack = Some (Pack8, SX); ordering = Unordered}
 let i64_load8_u align offset =
-  Load {ty = I64Type; align; offset; pack = Some (Pack8, ZX)}
+  Load {ty = I64Type; align; offset; pack = Some (Pack8, ZX); ordering = Unordered}
 let i64_load16_s align offset =
-  Load {ty = I64Type; align; offset; pack = Some (Pack16, SX)}
+  Load {ty = I64Type; align; offset; pack = Some (Pack16, SX); ordering = Unordered}
 let i64_load16_u align offset =
-  Load {ty = I64Type; align; offset; pack = Some (Pack16, ZX)}
+  Load {ty = I64Type; align; offset; pack = Some (Pack16, ZX); ordering = Unordered}
 let i64_load32_s align offset =
-  Load {ty = I64Type; align; offset; pack = Some (Pack32, SX)}
+  Load {ty = I64Type; align; offset; pack = Some (Pack32, SX); ordering = Unordered}
 let i64_load32_u align offset =
-  Load {ty = I64Type; align; offset; pack = Some (Pack32, ZX)}
+  Load {ty = I64Type; align; offset; pack = Some (Pack32, ZX); ordering = Unordered}
 
-let i32_store align offset = Store {ty = I32Type; align; offset; pack = None}
-let i64_store align offset = Store {ty = I64Type; align; offset; pack = None}
-let f32_store align offset = Store {ty = F32Type; align; offset; pack = None}
-let f64_store align offset = Store {ty = F64Type; align; offset; pack = None}
+let i32_store align offset = Store {ty = I32Type; align; offset; pack = None; ordering = Unordered}
+let i64_store align offset = Store {ty = I64Type; align; offset; pack = None; ordering = Unordered}
+let f32_store align offset = Store {ty = F32Type; align; offset; pack = None; ordering = Unordered}
+let f64_store align offset = Store {ty = F64Type; align; offset; pack = None; ordering = Unordered}
 let i32_store8 align offset =
-  Store {ty = I32Type; align; offset; pack = Some Pack8}
+  Store {ty = I32Type; align; offset; pack = Some Pack8; ordering = Unordered}
 let i32_store16 align offset =
-  Store {ty = I32Type; align; offset; pack = Some Pack16}
+  Store {ty = I32Type; align; offset; pack = Some Pack16; ordering = Unordered}
 let i64_store8 align offset =
-  Store {ty = I64Type; align; offset; pack = Some Pack8}
+  Store {ty = I64Type; align; offset; pack = Some Pack8; ordering = Unordered}
 let i64_store16 align offset =
-  Store {ty = I64Type; align; offset; pack = Some Pack16}
+  Store {ty = I64Type; align; offset; pack = Some Pack16; ordering = Unordered}
 let i64_store32 align offset =
-  Store {ty = I64Type; align; offset; pack = Some Pack32}
+  Store {ty = I64Type; align; offset; pack = Some Pack32; ordering = Unordered}
 
 let memory_atomic_notify align offset =
-  MemoryAtomicNotify {ty = I32Type; align; offset; pack = None}
+  MemoryAtomicNotify {ty = I32Type; align; offset; pack = None; ordering = SeqCst}
 
 let memory_atomic_wait32 align offset =
-  MemoryAtomicWait {ty = I32Type; align; offset; pack = None}
+  MemoryAtomicWait {ty = I32Type; align; offset; pack = None; ordering = SeqCst}
 let memory_atomic_wait64 align offset =
-  MemoryAtomicWait {ty = I64Type; align; offset; pack = None}
+  MemoryAtomicWait {ty = I64Type; align; offset; pack = None; ordering = SeqCst}
 
 let atomic_fence =
   AtomicFence
 
 let i32_atomic_load align offset =
-  AtomicLoad {ty = I32Type; align; offset; pack = None}
+  AtomicLoad {ty = I32Type; align; offset; pack = None; ordering = SeqCst}
 let i64_atomic_load align offset =
-  AtomicLoad {ty = I64Type; align; offset; pack = None}
+  AtomicLoad {ty = I64Type; align; offset; pack = None; ordering = SeqCst}
 let i32_atomic_load8_u align offset =
-  AtomicLoad {ty = I32Type; align; offset; pack = Some Pack8}
+  AtomicLoad {ty = I32Type; align; offset; pack = Some Pack8; ordering = SeqCst}
 let i32_atomic_load16_u align offset =
-  AtomicLoad {ty = I32Type; align; offset; pack = Some Pack16}
+  AtomicLoad {ty = I32Type; align; offset; pack = Some Pack16; ordering = SeqCst}
 let i64_atomic_load8_u align offset =
-  AtomicLoad {ty = I64Type; align; offset; pack = Some Pack8}
+  AtomicLoad {ty = I64Type; align; offset; pack = Some Pack8; ordering = SeqCst}
 let i64_atomic_load16_u align offset =
-  AtomicLoad {ty = I64Type; align; offset; pack = Some Pack16}
+  AtomicLoad {ty = I64Type; align; offset; pack = Some Pack16; ordering = SeqCst}
 let i64_atomic_load32_u align offset =
-  AtomicLoad {ty = I64Type; align; offset; pack = Some Pack32}
+  AtomicLoad {ty = I64Type; align; offset; pack = Some Pack32; ordering = SeqCst}
 
 let i32_atomic_store align offset =
-  AtomicStore {ty = I32Type; align; offset; pack = None}
+  AtomicStore {ty = I32Type; align; offset; pack = None; ordering = SeqCst}
 let i64_atomic_store align offset =
-  AtomicStore {ty = I64Type; align; offset; pack = None}
+  AtomicStore {ty = I64Type; align; offset; pack = None; ordering = SeqCst}
 let i32_atomic_store8 align offset =
-  AtomicStore {ty = I32Type; align; offset; pack = Some Pack8}
+  AtomicStore {ty = I32Type; align; offset; pack = Some Pack8; ordering = SeqCst}
 let i32_atomic_store16 align offset =
-  AtomicStore {ty = I32Type; align; offset; pack = Some Pack16}
+  AtomicStore {ty = I32Type; align; offset; pack = Some Pack16; ordering = SeqCst}
 let i64_atomic_store8 align offset =
-  AtomicStore {ty = I64Type; align; offset; pack = Some Pack8}
+  AtomicStore {ty = I64Type; align; offset; pack = Some Pack8; ordering = SeqCst}
 let i64_atomic_store16 align offset =
-  AtomicStore {ty = I64Type; align; offset; pack = Some Pack16}
+  AtomicStore {ty = I64Type; align; offset; pack = Some Pack16; ordering = SeqCst}
 let i64_atomic_store32 align offset =
-  AtomicStore {ty = I64Type; align; offset; pack = Some Pack32}
+  AtomicStore {ty = I64Type; align; offset; pack = Some Pack32; ordering = SeqCst}
 
 let i32_atomic_rmw rmwop align offset =
-  AtomicRmw (rmwop, {ty = I32Type; align; offset; pack = None})
+  AtomicRmw (rmwop, {ty = I32Type; align; offset; pack = None; ordering = SeqCst})
 let i64_atomic_rmw rmwop align offset =
-  AtomicRmw (rmwop, {ty = I64Type; align; offset; pack = None})
+  AtomicRmw (rmwop, {ty = I64Type; align; offset; pack = None; ordering = SeqCst})
 let i32_atomic_rmw8_u rmwop align offset =
-  AtomicRmw (rmwop, {ty = I32Type; align; offset; pack = Some Pack8})
+  AtomicRmw (rmwop, {ty = I32Type; align; offset; pack = Some Pack8; ordering = SeqCst})
 let i32_atomic_rmw16_u rmwop align offset =
-  AtomicRmw (rmwop, {ty = I32Type; align; offset; pack = Some Pack16})
+  AtomicRmw (rmwop, {ty = I32Type; align; offset; pack = Some Pack16; ordering = SeqCst})
 let i64_atomic_rmw8_u rmwop align offset =
-  AtomicRmw (rmwop, {ty = I64Type; align; offset; pack = Some Pack8})
+  AtomicRmw (rmwop, {ty = I64Type; align; offset; pack = Some Pack8; ordering = SeqCst})
 let i64_atomic_rmw16_u rmwop align offset =
-  AtomicRmw (rmwop, {ty = I64Type; align; offset; pack = Some Pack16})
+  AtomicRmw (rmwop, {ty = I64Type; align; offset; pack = Some Pack16; ordering = SeqCst})
 let i64_atomic_rmw32_u rmwop align offset =
-  AtomicRmw (rmwop, {ty = I64Type; align; offset; pack = Some Pack32})
+  AtomicRmw (rmwop, {ty = I64Type; align; offset; pack = Some Pack32; ordering = SeqCst})
 
 let i32_atomic_rmw_cmpxchg align offset =
-  AtomicRmwCmpXchg {ty = I32Type; align; offset; pack = None}
+  AtomicRmwCmpXchg {ty = I32Type; align; offset; pack = None; ordering = SeqCst}
 let i64_atomic_rmw_cmpxchg align offset =
-  AtomicRmwCmpXchg {ty = I64Type; align; offset; pack = None}
+  AtomicRmwCmpXchg {ty = I64Type; align; offset; pack = None; ordering = SeqCst}
 let i32_atomic_rmw8_u_cmpxchg align offset =
-  AtomicRmwCmpXchg {ty = I32Type; align; offset; pack = Some Pack8}
+  AtomicRmwCmpXchg {ty = I32Type; align; offset; pack = Some Pack8; ordering = SeqCst}
 let i32_atomic_rmw16_u_cmpxchg align offset =
-  AtomicRmwCmpXchg {ty = I32Type; align; offset; pack = Some Pack16}
+  AtomicRmwCmpXchg {ty = I32Type; align; offset; pack = Some Pack16; ordering = SeqCst}
 let i64_atomic_rmw8_u_cmpxchg align offset =
-  AtomicRmwCmpXchg {ty = I64Type; align; offset; pack = Some Pack8}
+  AtomicRmwCmpXchg {ty = I64Type; align; offset; pack = Some Pack8; ordering = SeqCst}
 let i64_atomic_rmw16_u_cmpxchg align offset =
-  AtomicRmwCmpXchg {ty = I64Type; align; offset; pack = Some Pack16}
+  AtomicRmwCmpXchg {ty = I64Type; align; offset; pack = Some Pack16; ordering = SeqCst}
 let i64_atomic_rmw32_u_cmpxchg align offset =
-  AtomicRmwCmpXchg {ty = I64Type; align; offset; pack = Some Pack32}
+  AtomicRmwCmpXchg {ty = I64Type; align; offset; pack = Some Pack32; ordering = SeqCst}
 
 let memory_size = MemorySize
 let memory_grow = MemoryGrow
@@ -305,51 +305,51 @@ let i64_reinterpret_f64 = Convert (I64 I64Op.ReinterpretFloat)
 let f32_reinterpret_i32 = Convert (F32 F32Op.ReinterpretInt)
 let f64_reinterpret_i64 = Convert (F64 F64Op.ReinterpretInt)
 
-let v128_load align offset = VecLoad {ty = V128Type; align; offset; pack = None}
+let v128_load align offset = VecLoad {ty = V128Type; align; offset; pack = None; ordering = Unordered}
 let v128_load8x8_s align offset =
-  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtLane (Pack8x8, SX))}
+  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtLane (Pack8x8, SX)); ordering = Unordered}
 let v128_load8x8_u align offset =
-  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtLane (Pack8x8, ZX))}
+  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtLane (Pack8x8, ZX)); ordering = Unordered}
 let v128_load16x4_s align offset =
-  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtLane (Pack16x4, SX))}
+  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtLane (Pack16x4, SX)); ordering = Unordered}
 let v128_load16x4_u align offset =
-  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtLane (Pack16x4, ZX))}
+  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtLane (Pack16x4, ZX)); ordering = Unordered}
 let v128_load32x2_s align offset =
-  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtLane (Pack32x2, SX))}
+  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtLane (Pack32x2, SX)); ordering = Unordered}
 let v128_load32x2_u align offset =
-  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtLane (Pack32x2, ZX))}
+  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtLane (Pack32x2, ZX)); ordering = Unordered}
 let v128_load8_splat align offset =
-  VecLoad {ty = V128Type; align; offset; pack = Some (Pack8, ExtSplat)}
+  VecLoad {ty = V128Type; align; offset; pack = Some (Pack8, ExtSplat); ordering = Unordered}
 let v128_load16_splat align offset =
-  VecLoad {ty = V128Type; align; offset; pack = Some (Pack16, ExtSplat)}
+  VecLoad {ty = V128Type; align; offset; pack = Some (Pack16, ExtSplat); ordering = Unordered}
 let v128_load32_splat align offset =
-  VecLoad {ty = V128Type; align; offset; pack = Some (Pack32, ExtSplat)}
+  VecLoad {ty = V128Type; align; offset; pack = Some (Pack32, ExtSplat); ordering = Unordered}
 let v128_load64_splat align offset =
-  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtSplat)}
+  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtSplat); ordering = Unordered}
 let v128_load32_zero align offset =
-  VecLoad {ty = V128Type; align; offset; pack = Some (Pack32, ExtZero)}
+  VecLoad {ty = V128Type; align; offset; pack = Some (Pack32, ExtZero); ordering = Unordered}
 let v128_load64_zero align offset =
-  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtZero)}
+  VecLoad {ty = V128Type; align; offset; pack = Some (Pack64, ExtZero); ordering = Unordered}
 
-let v128_store align offset = VecStore {ty = V128Type; align; offset; pack = ()}
+let v128_store align offset = VecStore {ty = V128Type; align; offset; pack = (); ordering = Unordered}
 
 let v128_load8_lane align offset i =
-  VecLoadLane ({ty = V128Type; align; offset; pack = Pack8}, i)
+  VecLoadLane ({ty = V128Type; align; offset; pack = Pack8; ordering = Unordered}, i)
 let v128_load16_lane align offset i =
-  VecLoadLane ({ty = V128Type; align; offset; pack = Pack16}, i)
+  VecLoadLane ({ty = V128Type; align; offset; pack = Pack16; ordering = Unordered}, i)
 let v128_load32_lane align offset i =
-  VecLoadLane ({ty = V128Type; align; offset; pack = Pack32}, i)
+  VecLoadLane ({ty = V128Type; align; offset; pack = Pack32; ordering = Unordered}, i)
 let v128_load64_lane align offset i =
-  VecLoadLane ({ty = V128Type; align; offset; pack = Pack64}, i)
+  VecLoadLane ({ty = V128Type; align; offset; pack = Pack64; ordering = Unordered}, i)
 
 let v128_store8_lane align offset i =
-  VecStoreLane ({ty = V128Type; align; offset; pack = Pack8}, i)
+  VecStoreLane ({ty = V128Type; align; offset; pack = Pack8; ordering = Unordered}, i)
 let v128_store16_lane align offset i =
-  VecStoreLane ({ty = V128Type; align; offset; pack = Pack16}, i)
+  VecStoreLane ({ty = V128Type; align; offset; pack = Pack16; ordering = Unordered}, i)
 let v128_store32_lane align offset i =
-  VecStoreLane ({ty = V128Type; align; offset; pack = Pack32}, i)
+  VecStoreLane ({ty = V128Type; align; offset; pack = Pack32; ordering = Unordered}, i)
 let v128_store64_lane align offset i =
-  VecStoreLane ({ty = V128Type; align; offset; pack = Pack64}, i)
+  VecStoreLane ({ty = V128Type; align; offset; pack = Pack64; ordering = Unordered}, i)
 
 let v128_not = VecUnaryBits (V128 V128Op.Not)
 let v128_and = VecBinaryBits (V128 V128Op.And)

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -191,7 +191,7 @@ let check_vec_binop binop at =
 
 type mem_mode = NonAtomic | Atomic
 
-let check_memop (mode : mem_mode) (c : context) (memop : ('t, 's) memop) ty_size get_sz at =
+let check_memop (mode : mem_mode) (c : context) (memop : ('t, 's, 'o) memop) ty_size get_sz at =
   let _mt = memory c (0l @@ at) in
   let size =
     match get_sz memop.pack with


### PR DESCRIPTION
For use in the [relaxed atomics proposal](https://github.com/WebAssembly/relaxed-atomics), e.g. https://github.com/WebAssembly/relaxed-atomics/pull/5 (based on top of this PR). This allows us to introduce more orderings (e.g. acqrel, and potentially others) to atomic instructions.

Keeping the ordering in the `memop` record allows us to avoid introducing a second `atomicmemop` record and duplicating several functions that use `memop` e.g. in [decode.ml](https://github.com/WebAssembly/threads/blob/979d0fcb994439423d63b2f0a8a7332d6285dd84/interpreter/binary/decode.ml#L223), [encode.ml](https://github.com/WebAssembly/threads/blob/979d0fcb994439423d63b2f0a8a7332d6285dd84/interpreter/binary/encode.ml#L149), [arrange.ml](https://github.com/WebAssembly/threads/blob/979d0fcb994439423d63b2f0a8a7332d6285dd84/interpreter/text/arrange.ml#L401-L409), and [valid.ml](https://github.com/WebAssembly/threads/blob/979d0fcb994439423d63b2f0a8a7332d6285dd84/interpreter/valid/valid.ml#L194).